### PR TITLE
fix: correctly parse content type

### DIFF
--- a/examples/cra/yarn.lock
+++ b/examples/cra/yarn.lock
@@ -971,7 +971,7 @@
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
 "@dhis2/app-runtime@file:../../runtime":
-  version "1.5.1"
+  version "2.0.0"
 
 "@hapi/address@2.x.x":
   version "2.0.0"

--- a/services/data/src/engine/links/RestAPILink/helpers/networkFetch.test.ts
+++ b/services/data/src/engine/links/RestAPILink/helpers/networkFetch.test.ts
@@ -1,7 +1,43 @@
-import { parseStatus, fetchData } from './networkFetch'
+import { parseStatus, fetchData, parseContentType } from './networkFetch'
 import { FetchError } from '../../../types/FetchError'
 
 describe('networkFetch', () => {
+    describe('parseContentType', () => {
+        it('should pass through simple content-types', () => {
+            expect(parseContentType('text/html')).toBe('text/html')
+            expect(parseContentType('text/plain')).toBe('text/plain')
+            expect(parseContentType('application/vnd.api+json')).toBe(
+                'application/vnd.api+json'
+            )
+        })
+
+        it('should strip parameters', () => {
+            expect(parseContentType('text/svg+xml;charset=utf-8')).toBe(
+                'text/svg+xml'
+            )
+            expect(parseContentType('text/html;testing123')).toBe('text/html')
+        })
+
+        it('should trim type', () => {
+            expect(parseContentType('   text/xml ')).toBe('text/xml')
+            expect(
+                parseContentType(' application/json ; charset = utf-8')
+            ).toBe('application/json')
+        })
+
+        it('should convert to lower-case', () => {
+            expect(parseContentType('  Text/XML ')).toBe('text/xml')
+            expect(parseContentType('application/JSON ; charset = UTF-8')).toBe(
+                'application/json'
+            )
+        })
+
+        it('should correctly parse application/json with charset param', () => {
+            expect(parseContentType('application/json;charset=UTF-8')).toBe(
+                'application/json'
+            )
+        })
+    })
     describe('parseStatus', () => {
         it('should pass through the response for a success status code', async () => {
             const response: any = {

--- a/services/data/src/engine/links/RestAPILink/helpers/networkFetch.ts
+++ b/services/data/src/engine/links/RestAPILink/helpers/networkFetch.ts
@@ -1,6 +1,15 @@
 import { FetchError } from '../../../types/FetchError'
 import { JsonValue } from '../../../types/JsonValue'
 
+export const parseContentType = (contentType: string | null) => {
+    return contentType
+        ? contentType
+              .split(';')[0]
+              .trim()
+              .toLowerCase()
+        : null
+}
+
 export const parseStatus = async (response: Response) => {
     if (
         response.status === 401 ||
@@ -54,7 +63,10 @@ export function fetchData(
         })
         .then(parseStatus)
         .then(async response => {
-            if (response.headers.get('Content-Type') === 'application/json') {
+            if (
+                parseContentType(response.headers.get('Content-Type')) ===
+                'application/json'
+            ) {
                 return await response.json() // Will throw if invalid JSON!
             }
             return await response.text()


### PR DESCRIPTION
This was causing nasty errors, so I'm going to go ahead and merge it to un-break production.

Reason: DHIS2 returns `Content-Type: application/json; charset=UTF-8`, which isn't **exactly** application/json and so caused the link to skip JSON parsing.