### PR TITLE
fix: correct support for duplicate keys

### DIFF
--- a/services/data/src/engine/types/QueryParameters.ts
+++ b/services/data/src/engine/types/QueryParameters.ts
@@ -2,7 +2,7 @@ type QueryParameterSingularValue = string | number
 interface QueryParameterAliasedValue {
     [name: string]: QueryParameterSingularValue
 }
-type QueryParameterSingularOrAliasedValue =
+export type QueryParameterSingularOrAliasedValue =
     | QueryParameterSingularValue
     | QueryParameterAliasedValue
 

--- a/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
@@ -100,7 +100,7 @@ describe('queryToResourcePath', () => {
             },
         }
         expect(queryToResourcePath(apiPath, query)).toBe(
-            `${apiPath}/test?key=asdf,123`
+            `${apiPath}/test?key=asdf&key=123`
         )
     })
     it('should NOT YET support name-aliased parameters', () => {
@@ -111,6 +111,18 @@ describe('queryToResourcePath', () => {
             },
         }
         expect(() => queryToResourcePath(apiPath, query)).toThrow()
+    })
+    it('should ignore undefined parameters', () => {
+        const query: ResolvedResourceQuery = {
+            resource: 'test',
+            params: {
+                key: 42,
+                param: undefined,
+            },
+        }
+        expect(queryToResourcePath(apiPath, query)).toBe(
+            `${apiPath}/test?key=42`
+        )
     })
     it('should throw if passed something crazy like a function', () => {
         const query: ResolvedResourceQuery = {


### PR DESCRIPTION
This changes the array behavior for param objects, so that `fields: ['foo', 'barr']` expands to `fields=foo&fields=bar` instead of `fields=foo,bar`.

This is more verbose, unfortunately, but does allow us to support multiple filters, which requires the multiple-key format.  The alternative would be to special-case the `filter` param, which is also not ideal but a possible alternative.

I've asked the #webapi channel on Slack about which of these is preferred, but no response yet.  A third alternative would be to support a control-character junction in the `filter` querystring paramter, like `filter=name:eq:hello,geometry:!null` (picking the same control character as `fields`, we then escape `,` in each of the items and join them with `,` - the current behavior).