### PR TITLE
fix(parsestatus): add response data to error

### DIFF
--- a/services/data/src/engine/types/FetchError.ts
+++ b/services/data/src/engine/types/FetchError.ts
@@ -1,17 +1,17 @@
 export type FetchErrorTypeName = 'network' | 'unknown' | 'access' | 'aborted'
-export type FetchErrorDetails = Response | Error
+export type FetchErrorDetails = { message?: string }
 
 export interface FetchErrorPayload {
     type: FetchErrorTypeName
-    message: string
     details?: FetchErrorDetails
+    message: string
 }
 
 export class FetchError extends Error implements FetchErrorPayload {
     public type: FetchErrorTypeName
-    public details?: FetchErrorDetails
+    public details: FetchErrorDetails
 
-    public constructor({ message, type, details }: FetchErrorPayload) {
+    public constructor({ message, type, details = {} }: FetchErrorPayload) {
         super(message)
         this.type = type
         this.details = details

--- a/services/data/src/links/RestAPILink/fetchData.test.ts
+++ b/services/data/src/links/RestAPILink/fetchData.test.ts
@@ -38,6 +38,7 @@ describe('networkFetch', () => {
             )
         })
     })
+
     describe('parseStatus', () => {
         it('should pass through the response for a success status code', async () => {
             const response: any = {
@@ -46,45 +47,48 @@ describe('networkFetch', () => {
             await expect(parseStatus(response)).resolves.toBe(response)
         })
 
-        it('should throw an access error for 401, 403, and 409 errors', async () => {
-            const response: any = {
+        it('should throw an access error for 401, 403 and 409 errors', async () => {
+            const response401: any = {
                 status: 401,
                 json: async () => {
                     throw new Error()
                 },
             }
-            expect(parseStatus(response)).rejects.toMatchObject({
-                type: 'access',
-                message: 'Unauthorized',
-                details: response,
-            })
-
-            const response3: any = {
+            const response403: any = {
                 status: 403,
                 json: async () => {
                     throw new Error()
                 },
             }
-            expect(parseStatus(response3)).rejects.toMatchObject({
-                type: 'access',
-                message: 'Forbidden',
-                details: response3,
-            })
-
-            const response9: any = {
+            const response409: any = {
                 status: 409,
                 json: async () => ({
                     message: 'An error occurred',
                 }),
             }
-            expect(parseStatus(response9)).rejects.toMatchObject({
+
+            expect(parseStatus(response401)).rejects.toMatchObject({
+                type: 'access',
+                message: 'Unauthorized',
+                details: {},
+            })
+
+            expect(parseStatus(response403)).rejects.toMatchObject({
+                type: 'access',
+                message: 'Forbidden',
+                details: {},
+            })
+
+            expect(parseStatus(response409)).rejects.toMatchObject({
                 type: 'access',
                 message: 'An error occurred',
-                details: response9,
+                details: {
+                    message: 'An error occurred',
+                },
             })
         })
 
-        it('Should throw if an unknown error occurs', () => {
+        it('should throw if an unknown error occurs', () => {
             const response: any = {
                 status: 500,
                 statusText: 'Failed',
@@ -95,7 +99,9 @@ describe('networkFetch', () => {
             expect(parseStatus(response)).rejects.toMatchObject({
                 type: 'unknown',
                 message: `An unknown error occurred - Failed (500)`,
-                details: response,
+                details: {
+                    message: 'An error occurred',
+                },
             })
         })
     })


### PR DESCRIPTION
As discussed on [app-platform](https://dhis2.slack.com/archives/CLJSVA1RV/p1586945462166900). The body of the response that was attached to the error was already parsed, so once it reaches the app, it can't be parsed a second time and the data was lost.

This attaches the parsed data to the error under error.details (it if can be parsed). So error.details will now no longer be the response object.

p.s.: I used a try catch block as I found the synchronous notation easier to read in combination with async/await, but that's a bit subjective, so let me know if you'd like me to use the promise api.