### PR TITLE
Features

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "build:services": "yarn build:config && loop \"yarn build\" --cwd ./services --exclude config --exit-on-error",
         "build:runtime": "cd runtime && yarn build",
         "build": "yarn build:services && yarn build:runtime && yarn install:examples",
+        "test:integration": "cd ./services/data && yarn test:integration",
         "test:services": "loop \"yarn test\" --cwd ./services --exit-on-error",
         "test:runtime": "cd runtime && yarn test",
         "test": "yarn test:services && yarn test:runtime",

--- a/services/data/features/abort_mutation.feature
+++ b/services/data/features/abort_mutation.feature
@@ -1,0 +1,6 @@
+Feature: A pending mutation request can be aborted
+
+    Scenario: A mutation request gets cancelled
+        Given a mutation request is pending
+        When the abort function is called
+        Then the request stops

--- a/services/data/features/abort_query.feature
+++ b/services/data/features/abort_query.feature
@@ -1,0 +1,6 @@
+Feature: A pending query request can be aborted
+
+    Scenario: A query request gets cancelled
+        Given a query request is pending
+        When the abort function is called
+        Then the request stops

--- a/services/data/features/action_resources.feature
+++ b/services/data/features/action_resources.feature
@@ -1,0 +1,9 @@
+Feature: DHIS 2 specific action resources can be requested
+
+    Scenario: A resource's string representation contains the action prefix
+        Given a query's resource is an action endpoint
+        Then the request url contains the action endpoint specific path segments
+
+    Scenario: A resource's string representation does not contain the action prefix
+        Given a query's resource is not an action endpoint
+        Then the request url does not contain the action endpoint specific path segments

--- a/services/data/features/filter_query_params.feature
+++ b/services/data/features/filter_query_params.feature
@@ -1,0 +1,9 @@
+Feature: Multiple "filter" parameters are sent individually
+
+    Scenario: A resource query has one filter value
+        Given a query is provided one filter parameter value
+        Then the request url contains one filter key value pair
+
+    Scenario: A resource query has more than one filter value
+        Given a query is provided multipe filter parameter values
+        Then the request url contains a filter key value pair for each provided value

--- a/services/data/features/mutate_resources.feature
+++ b/services/data/features/mutate_resources.feature
@@ -1,0 +1,25 @@
+Feature: One or many resources can be requested
+
+    Scenario: Requesting a single resource with a data response
+        Given the "me" is being requested
+        When the request succeeds
+        Then the result includes the values of the "me" resource
+
+    Scenario: Requesting a set of resources with a data response
+        Given the "me" and "systemSettings" are being requested
+        When the request succeeds
+        Then both the result includes all values of the requested set of resources
+
+    Scenario: Requesting a single resource with an error response
+        Given the "me" are being requested
+        When the request succeeds
+        But the response contains an error
+        Then the result contains the error
+        And the result does not contain any data
+
+    Scenario: Requesting a set of resources with an error response
+        Given the "me" and "systemSettings" are being requested
+        When the request succeeds
+        But the response contains an error
+        Then the result contains the error
+        And the result does not contain any data for any resource

--- a/services/data/features/mutations_accepts_dynamic_variables.feature
+++ b/services/data/features/mutations_accepts_dynamic_variables.feature
@@ -1,0 +1,11 @@
+Feature: A static mutation can be executed with dynamic parameters
+
+    Scenario: A mutation's parameters property is a function that expects a value and is executed with a value
+        Given a mutation expects a value for a parameter
+        When the mutation is executed with a value for that parameter
+        Then the request contains a key value pair with the parameter and the provided value
+
+    Scenario: A mutation's parameters property is a function that expects a value and is executed without a value
+        Given a mutation expects a value for a parameter
+        When the mutation is executed without a value for that parameter
+        Then the request throws an error and rejects

--- a/services/data/features/parallel_requests.feature
+++ b/services/data/features/parallel_requests.feature
@@ -1,0 +1,13 @@
+Feature: Requested resources of one query are being executed in parallel
+
+    Scenario: The consumer requests multiple resources
+        Given multiple resources are summarized in one query
+        And the query has been executed
+        Then all resources should be fetched in parallel
+
+    Scenario: The consumer receives the response of multilple resources
+        Given multiple resources are summarized in one query
+        And not all resources have finished
+        Then the query is still pending
+        When all resources finish loading
+        Then then the query responds with all resource responses

--- a/services/data/features/queries_accepts_dynamic_variables.feature
+++ b/services/data/features/queries_accepts_dynamic_variables.feature
@@ -1,0 +1,11 @@
+Feature: A static query can be executed with dynamic parameters
+
+    Scenario: A query's parameters property is a function that expects a value and is executed with a value
+        Given a query expects a value for a parameter
+        When the query is executed with a value for that parameter
+        Then the request contains a key value pair with the parameter and the provided value
+
+    Scenario: A query's parameters property is a function that expects a value and is executed without a value
+        Given a query expects a value for a parameter
+        When the query is executed without a value for that parameter
+        Then the request throws an error and rejects

--- a/services/data/features/resource_request_types.feature
+++ b/services/data/features/resource_request_types.feature
@@ -1,0 +1,22 @@
+Feature: Mutations can have a type to transport their intended type of change
+
+    Scenario: The user wants to add a new item
+        Given a mutation's resource has type "create"
+        Then the method of the request is of type "POST"
+
+    Scenario: The user wants to add a update an existing item
+        Given a mutation's resource has type "update"
+        Then the method of the request is of type "PATCH"
+
+    Scenario: The user wants to add a replace an existing item
+        Given a mutation's resource has type "replace"
+        Then the method of the request is of type "PUT"
+
+    Scenario: The user wants to add a replace an existing item partially
+        Given a mutation's resource has type "replace"
+        And the mutation's resource only wants to replace partial data
+        Then the method of the request is of type "PATCH"
+
+    Scenario: The user wants to add a delete an existing item
+        Given a mutation's resource has type "delete"
+        Then the method of the request is of type "DELETE"

--- a/services/data/features/validate_mutation.feature
+++ b/services/data/features/validate_mutation.feature
@@ -1,0 +1,48 @@
+Feature: Mutations are being validated
+
+    Scenario: The user supplies an valid mutation
+        Given a mutation is valid
+        Then the mutation should be executed
+
+    Scenario: The provided mutation's type is invalid
+        Given one of the mutation's resource's type does not exist
+        Then the mutation should reject with an error
+
+    Scenario: The provided mutation lacks a type
+        Given one of the mutation's resource does not have a type
+        Then the mutation should reject with an error
+
+    Scenario: The provided mutation is not an object
+        Given the mutation is not an object
+        Then the mutation should reject with an error
+
+    Scenario: One of the resources is not an object
+        Given one of the mutation's resources is not an object
+        Then the mutation should reject with an error
+
+    Scenario: The provided mutation lacks a resource
+        Given the mutation is empty
+        Then the mutation should reject with an error
+
+    Scenario: The provided mutation's resource is not a string
+        Given one of the mutation's resource's name is not a string
+        Then the mutation should reject with an error
+
+    Scenario: The provided mutation is of type "create" and has an id property
+        Given one of the resources is of type "create"
+        And the resource has an id property
+        Then the mutation should reject with an error
+
+    Scenario: The provided mutation's id is not a string
+        Given one of the resources has an id property
+        And the id is not a string
+        Then the mutation should reject with an error
+
+    Scenario: The provided mutation is of type "delete" and has a data property
+        Given one of the resources is of type "delete"
+        And the resource has a data property
+        Then the mutation should reject with an error
+
+    Scenario: The provided mutation contains invalid properties
+        Given one of the mutation's resources has an invalid property
+        Then the mutation should reject with an error

--- a/services/data/features/validate_queries.feature
+++ b/services/data/features/validate_queries.feature
@@ -1,0 +1,48 @@
+Feature: Queries are being validated
+
+    Scenario: The user supplies an valid query
+        Given a query is valid
+        Then the query should be executed
+
+    Scenario: The provided query's type is invalid
+        Given one of the query's resource's type does not exist
+        Then the query should reject with an error
+
+    Scenario: The provided query lacks a type
+        Given one of the query's resource does not have a type
+        Then the query should reject with an error
+
+    Scenario: The provided query is not an object
+        Given the query is not an object
+        Then the query should reject with an error
+
+    Scenario: One of the resources is not an object
+        Given one of the query's resources is not an object
+        Then the query should reject with an error
+
+    Scenario: The provided query lacks a resource
+        Given the query is empty
+        Then the query should reject with an error
+
+    Scenario: The provided query's resource is not a string
+        Given one of the query's resource's name is not a string
+        Then the query should reject with an error
+
+    Scenario: The provided query is of type "create" and has an id property
+        Given one of the resources is of type "create"
+        And the resource has an id property
+        Then the query should reject with an error
+
+    Scenario: The provided query's id is not a string
+        Given one of the resources has an id property
+        And the id is not a string
+        Then the query should reject with an error
+
+    Scenario: The provided query is of type "delete" and has a data property
+        Given one of the resources is of type "delete"
+        And the resource has a data property
+        Then the query should reject with an error
+
+    Scenario: The provided query contains invalid properties
+        Given one of the query's resources has an invalid property
+        Then the query should reject with an error

--- a/services/data/jest.integration.config.js
+++ b/services/data/jest.integration.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+    roots: ['<rootDir>/test'],
+    transform: {
+        '^.+\\.tsx?$': 'ts-jest',
+    },
+    testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+
+    collectCoverageFrom: ['src/**/*.(js|jsx|ts|tsx)', '!src/index.ts'],
+
+    // Setup react-testing-library
+    setupFilesAfterEnv: ['<rootDir>/src/setupRTL.ts'],
+}

--- a/services/data/package.json
+++ b/services/data/package.json
@@ -27,7 +27,11 @@
         "type-check": "tsc --noEmit --allowJs --checkJs",
         "type-check:watch": "yarn type-check --watch",
         "test": "jest",
+        "test:integration": "jest --config jest.integration.config.js",
         "coverage": "jest --coverage",
         "prepublishOnly": "yarn build"
+    },
+    "devDependencies": {
+        "jest-cucumber": "^2.0.11"
     }
 }

--- a/services/data/test/abort_mutation.spec.ts
+++ b/services/data/test/abort_mutation.spec.ts
@@ -1,0 +1,69 @@
+import * as path from 'path'
+import { defineFeature, loadFeature } from 'jest-cucumber'
+import { DataEngine } from '../src/engine/DataEngine'
+import { RestAPILink } from '../src/links/RestAPILink'
+import { fetchData } from '../src/links/RestAPILink/fetchData'
+
+jest.mock('../src/links/RestAPILink/fetchData', () => ({
+    fetchData: jest.fn((url, options) => Promise.resolve({ url, options })),
+}))
+
+const featurePath = path.join(__dirname, '../features/abort_mutation.feature')
+const feature = loadFeature(featurePath)
+
+defineFeature(feature, test => {
+    const baseUrl = 'https://www.domain.tld'
+    const apiVersion = 111
+
+    const onComplete = jest.fn()
+    const onError = jest.fn()
+
+    afterEach(() => {
+        onComplete.mockClear()
+        onError.mockClear()
+    })
+
+    test('A mutation request gets cancelled', ({ given, when, then }) => {
+        const controller = new AbortController()
+        const link = new RestAPILink({ baseUrl, apiVersion })
+        const engine = new DataEngine(link)
+
+        given('a mutation request is pending', () => {
+            const fetchFn = fetchData as jest.Mock
+            fetchFn.mockImplementationOnce(
+                // forever in pending state
+                () => new Promise(() => null)
+            )
+
+            const query = {
+                me: {
+                    resource: 'me',
+                    type: 'create',
+                    data: {
+                        foo: 'foo',
+                        bar: 'bar',
+                    },
+                },
+            }
+
+            const options = {
+                signal: controller.signal,
+            }
+
+            engine
+                .query(query, options)
+                .then(onComplete)
+                .catch(onError)
+        })
+
+        when('the abort function is called', () => {
+            controller.abort()
+        })
+
+        then('the request stops', () => {
+            expect(controller.signal.aborted).toBe(true)
+            expect(onComplete).toHaveBeenCalledTimes(0)
+            expect(onError).toHaveBeenCalledTimes(0)
+        })
+    })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,7 +1421,7 @@
     jest-diff "^25.1.0"
     pretty-format "^25.1.0"
 
-"@types/jest@^24.9.0":
+"@types/jest@^24.0.7", "@types/jest@^24.9.0":
   version "24.9.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
   integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
@@ -1437,6 +1437,11 @@
   version "13.9.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.3.tgz#6356df2647de9eac569f9a52eda3480fa9e70b4d"
   integrity sha512-01s+ac4qerwd6RHD+mVbOEsraDHSgUaefQlEdBbUolnQFjKwCr7luvAlEwW1RFojh67u0z4OUTjPn9LEl4zIkA==
+
+"@types/node@^11.9.4":
+  version "11.15.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.12.tgz#bf5d348c4d37c026029ad81e874946fa6ad100ba"
+  integrity sha512-iefeBfpmhoYaZfj+gJM5z9H9eiTwhuzhPsJgH/flx4HP2SBI2FNDra1D3vKljqPLGDr9Cazvh9gP9Xszc30ncA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -3638,6 +3643,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gherkin@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/gherkin/-/gherkin-5.1.0.tgz#684bbb03add24eaf7bdf544f58033eb28fb3c6d5"
+  integrity sha1-aEu7A63STq9731RPWAM+so+zxtU=
+
 git-raw-commits@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.3.tgz#f040e67b8445962d4d168903a9e84c4240c17655"
@@ -4404,6 +4414,17 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
+jest-cucumber@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/jest-cucumber/-/jest-cucumber-2.0.11.tgz#e8d1449bee23110693d73a879d94a0dc3e352406"
+  integrity sha512-5r3T21sGiFaJpWT4CKV244SdFozcPPGaZxpgDlNRNMy7ye8qODoDp2+z4BU/DbeaQDDjmY/xHFn47EYpBG2xkw==
+  dependencies:
+    "@types/jest" "^24.0.7"
+    "@types/node" "^11.9.4"
+    callsites "^3.0.0"
+    gherkin "^5.0.0"
+    jest "^24.1.0"
+
 jest-diff@^24.3.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
@@ -4724,7 +4745,7 @@ jest-worker@^24.6.0, jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest@^24.9.0:
+jest@^24.1.0, jest@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
   integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==


### PR DESCRIPTION
Relates to dhis2/app-platform#380

I saw that the repository is covered with an quite exhaustive unit test suite.
First I thought about adding integration tests with storybook and cypress, only to realize that the same feature files could be used to do integration tests of the non-react part (engine + link).

The big difference to the unit tests is that the link is not mocked, only the actual fetch function (`fetchData.ts`).

Also we could use the same feature files + storybook to cover the react components/hooks. In the future we could replace mocking the fetch functionality with spinning up an instance with docker and do actual e2e tests through the local network.

These jest-cucumber tests should only use the publicly exposed parts instead of mocking internals to make sure the integration of several units works as expected

<hr />

But instead of writing a lot of tests, I wanted to get some feedback first to see whether you guys think that this actually makes sense.