### PR TITLE
fix: support boolean values for query parameters

### DIFF
--- a/services/data/src/engine/types/QueryParameters.ts
+++ b/services/data/src/engine/types/QueryParameters.ts
@@ -1,4 +1,4 @@
-type QueryParameterSingularValue = string | number
+type QueryParameterSingularValue = string | number | boolean
 interface QueryParameterAliasedValue {
     [name: string]: QueryParameterSingularValue
 }

--- a/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
@@ -92,6 +92,18 @@ describe('queryToResourcePath', () => {
             `${apiPath}/test?key=42&param=193.75`
         )
     })
+    it('should support boolean parameters', () => {
+        const query: ResolvedResourceQuery = {
+            resource: 'test',
+            params: {
+                key: 42,
+                someflag: true,
+            },
+        }
+        expect(queryToResourcePath(apiPath, query)).toBe(
+            `${apiPath}/test?key=42&someflag=true`
+        )
+    })
     it('should join array parameters with commas', () => {
         const query: ResolvedResourceQuery = {
             resource: 'test',

--- a/services/data/src/links/RestAPILink/queryToResourcePath.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.ts
@@ -12,7 +12,7 @@ const encodeQueryParameter = (param: QueryParameterValue): string => {
     if (typeof param === 'string') {
         return encodeURIComponent(param)
     }
-    if (typeof param === 'number') {
+    if (typeof param === 'number' || typeof param === 'boolean') {
         return String(param)
     }
     if (typeof param === 'object') {


### PR DESCRIPTION
Fixes #578 