### PR TITLE
feat: add explicit support for systemInfo and serverVersion config props

### DIFF
--- a/services/config/src/__tests__/integration.test.tsx
+++ b/services/config/src/__tests__/integration.test.tsx
@@ -8,6 +8,16 @@ import { ConfigContext } from '../ConfigContext'
 const mockConfig: Config = {
     baseUrl: 'http://test.com',
     apiVersion: 42,
+    serverVersion: {
+        major: 2,
+        minor: 35,
+        patch: undefined,
+        tag: 'SNAPSHOT',
+    },
+    systemInfo: {
+        contextPath: 'http://localhost:3000',
+        version: '2.35-SNAPSHOT',
+    },
 }
 
 describe('Testing custom config provider', () => {

--- a/services/config/src/types.ts
+++ b/services/config/src/types.ts
@@ -13,6 +13,6 @@ interface SystemInfo {
 export interface Config {
     baseUrl: string
     apiVersion: number
-    serverVersion: ServerVersion
-    systemInfo: SystemInfo
+    serverVersion?: ServerVersion
+    systemInfo?: SystemInfo
 }

--- a/services/config/src/types.ts
+++ b/services/config/src/types.ts
@@ -2,7 +2,7 @@ type ServerVersion = {
     major: number
     minor: number
     patch?: number
-    tag: string
+    tag?: string
 }
 
 interface SystemInfo {

--- a/services/config/src/types.ts
+++ b/services/config/src/types.ts
@@ -1,4 +1,18 @@
+type ServerVersion = {
+    major: number
+    minor: number
+    patch?: number
+    tag: string
+}
+
+interface SystemInfo {
+    version: string
+    contextPath: string
+}
+
 export interface Config {
     baseUrl: string
     apiVersion: number
+    serverVersion: ServerVersion
+    systemInfo: SystemInfo
 }


### PR DESCRIPTION
This adds typescript annotations for `systemInfo` and `serverVersion` properties on the Config context object.

Note that these are currently added as Optional properties to avoid causing a breaking change, but eventually we will want them to be required.