### PR TITLE
feat: add support for svg conversion end-point (libs-105)

### DIFF
--- a/services/data/src/links/RestAPILink/fetchData.test.ts
+++ b/services/data/src/links/RestAPILink/fetchData.test.ts
@@ -113,7 +113,7 @@ describe('networkFetch', () => {
                     ? 'application/json'
                     : type === 'text'
                     ? 'text/plain'
-                    : 'image/png',
+                    : 'some/other-content-type',
         }
         const mockFetch = jest.fn(async url => ({
             status: 200,

--- a/services/data/src/links/RestAPILink/fetchData.test.ts
+++ b/services/data/src/links/RestAPILink/fetchData.test.ts
@@ -109,7 +109,11 @@ describe('networkFetch', () => {
     describe('fetchData', () => {
         const headers: Record<string, (type: string) => string> = {
             'Content-Type': type =>
-                type === 'json' ? 'application/json' : 'text/plain',
+                type === 'json'
+                    ? 'application/json'
+                    : type === 'text'
+                    ? 'text/plain'
+                    : 'image/png',
         }
         const mockFetch = jest.fn(async url => ({
             status: 200,
@@ -118,6 +122,7 @@ describe('networkFetch', () => {
             },
             json: async () => ({ foo: 'bar' }),
             text: async () => 'foobar',
+            blob: async () => 'blob of foobar',
         }))
         beforeEach(() => {
             jest.clearAllMocks()
@@ -133,6 +138,11 @@ describe('networkFetch', () => {
         it('Should correctly parse a successful TEXT response', () => {
             ;(global as any).fetch = mockFetch
             expect(fetchData('text')).resolves.toBe('foobar')
+        })
+
+        it('Should correctly parse a successful BLOB response', () => {
+            ;(global as any).fetch = mockFetch
+            expect(fetchData('something else')).resolves.toBe('blob of foobar')
         })
 
         it('Should throw a FetchError if fetch fails', () => {

--- a/services/data/src/links/RestAPILink/fetchData.ts
+++ b/services/data/src/links/RestAPILink/fetchData.ts
@@ -84,7 +84,7 @@ export function fetchData(
             }
 
             // 'text/*'
-            if (/^text\/[a-z0-9.-]*$/.test(contentType)) {
+            if (/^text\/[a-z0-9.-]+$/.test(contentType)) {
                 return await response.text()
             }
 

--- a/services/data/src/links/RestAPILink/fetchData.ts
+++ b/services/data/src/links/RestAPILink/fetchData.ts
@@ -1,8 +1,7 @@
 import { FetchError, FetchErrorDetails, JsonValue } from '../../engine'
 
-export const parseContentType = (contentType: string | null) => {
-    return contentType ? contentType.split(';')[0].trim().toLowerCase() : null
-}
+export const parseContentType = (contentType: string | null) =>
+    contentType ? contentType.split(';')[0].trim().toLowerCase() : ''
 
 export const parseStatus = async (response: Response) => {
     const accessError =
@@ -75,12 +74,20 @@ export function fetchData(
         })
         .then(parseStatus)
         .then(async response => {
-            if (
-                parseContentType(response.headers.get('Content-Type')) ===
-                'application/json'
-            ) {
+            const contentType = parseContentType(
+                response.headers.get('Content-Type')
+            )
+
+            // 'application/json'
+            if (contentType === 'application/json') {
                 return await response.json() // Will throw if invalid JSON!
             }
-            return await response.text()
+
+            // 'text/*'
+            if (/^text\/[a-z0-9.-]*$/.test(contentType)) {
+                return await response.text()
+            }
+
+            return await response.blob()
         })
 }

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/multipartFormDataMatchers.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/multipartFormDataMatchers.test.ts
@@ -3,6 +3,7 @@ import {
     isMessageConversationAttachment,
     isStaticContentUpload,
     isAppInstall,
+    isSvgConversion,
 } from './multipartFormDataMatchers'
 
 describe('isFileResourceUpload', () => {
@@ -64,7 +65,7 @@ describe('isStaticContentUpload', () => {
 })
 
 describe('isAppInstall', () => {
-    it('returns true for a POST to "fileResources"', () => {
+    it('returns true for a POST to "apps"', () => {
         expect(
             isAppInstall('create', {
                 resource: 'apps',
@@ -75,6 +76,30 @@ describe('isAppInstall', () => {
         expect(
             isAppInstall('create', {
                 resource: 'notApps',
+            })
+        ).toEqual(false)
+    })
+})
+
+describe('isSvgConversion', () => {
+    it('returns true for a POST to "svg.png"', () => {
+        expect(
+            isSvgConversion('create', {
+                resource: 'svg.png',
+            })
+        ).toEqual(true)
+    })
+    it('returns true for a POST to "svg.pdf"', () => {
+        expect(
+            isSvgConversion('create', {
+                resource: 'svg.pdf',
+            })
+        ).toEqual(true)
+    })
+    it('retuns false for a POST to a different resource', () => {
+        expect(
+            isSvgConversion('create', {
+                resource: 'notSvg',
             })
         ).toEqual(false)
     })

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/multipartFormDataMatchers.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/multipartFormDataMatchers.ts
@@ -32,3 +32,9 @@ export const isAppInstall = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
 ) => type === 'create' && resource === 'apps'
+
+// POST to convert an SVG file
+export const isSvgConversion = (
+    type: FetchType,
+    { resource }: ResolvedResourceQuery
+) => type === 'create' && (resource === 'svg.png' || resource === 'svg.pdf')

--- a/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
@@ -28,6 +28,16 @@ describe('queryToResourcePath', () => {
             )
         })
     })
+    describe('resource with dot', () => {
+        it('should leave dots in resources', () => {
+            const query: ResolvedResourceQuery = {
+                resource: 'svg.pdf',
+            }
+            expect(queryToResourcePath(apiPath, query)).toBe(
+                `${apiPath}/svg.pdf`
+            )
+        })
+    })
     it('should return resource url with no querystring if not query parameters are passed', () => {
         const query: ResolvedResourceQuery = {
             resource: 'test',


### PR DESCRIPTION
For some more context, see [this Slack thread](https://dhis2.slack.com/archives/CLJSVA1RV/p1611577363000400). This PR contains the following:
- The file `multipartFormDataMatchers.ts` now contains a function that matches the `api/svg.png` or `api/svg.pdf` endpoint, which requires a `FormData` instance as the request body.
- We now try to parse the response data correctly depending on the content-type.
