### PR TITLE
feat(alerts-service): let `useAlert` return a hide function (LIBS-114)

### DIFF
--- a/docs/hooks/useAlert.md
+++ b/docs/hooks/useAlert.md
@@ -1,17 +1,25 @@
 # `useAlert`
 
-`useAlert(message, options?) → { show }`
+`useAlert(message, options?) → { show, hide }`
 
 ## Hook arguments
 
-| Name      | Type                   | Description                                                                                                                                                                                                                                                              |
-| --------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `message` | `string` or `Function` | The message to display                                                                                                                                                                                                                                                   |
-| `options` | `object` or `Function` | A configuration object that matches [the props of the `AlertBar`](https://ui.dhis2.nu/demo/?path=/docs/feedback-alerts-alert-bar--default) in `@dhis2/ui` (alternate: [minimal view](https://ui.dhis2.nu/#/api?id=coresrcalertbaralertbarproptypes-object) of the props) |
+| Name      | Type                   | Description                                                                                                 |
+| --------- | ---------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `message` | `string` or `Function` | The message to display                                                                                      |
+| `options` | `object` or `Function` | A configuration object for the alert. See [note](#note) below for usage instructions in DHIS2 platform-apps |
+
+## Usage in apps built on the DHIS2 app platform
+
+The DHIS2 app-shell comes with the alerts provider and a component to show `AlertBar`s in an `AlertStack` (a `@dhis2/ui` components), so in a typical DHIS2 platform app only the `useAlert` hook is used and it can be imported from `@dhis2/app-runtime`.
+
+When used in an app build on the DHIS2 platform (using `@dhis2/cli-app-scripts`), the `options` argument should be an object with properties that match the [props of an `AlertBar`](https://ui.dhis2.nu/#/api?id=alertbar).
 
 ## Usage of the returned `show` function
 
 `show(props?) → void`
+
+### Static alerts
 
 When the `useAlert` hook receives the `message` argument as a `string` and the `options` argument as an `object`, the `show` function should be called without any arguments, for example:
 
@@ -22,7 +30,11 @@ const { show } = useAlert('My alert message', { duration: 3000 })
 show()
 ```
 
-When providing functions as arguments to the `useAlert` hook, you can pass arbitrary arguments to the `show` function to make a more dynamic alert, for example:
+When using static arguments calling `show` multiple times is a no-op.
+
+### Dynamic alerts
+
+When providing functions as arguments to the `useAlert` hook, it's possible to pass arbitrary arguments to the `show` function to make a more dynamic alert, for example:
 
 ```js
 // Create the alert
@@ -38,8 +50,16 @@ show({ username: 'hendrik', isCurrentUser: true })
 // options: { critical: true }
 ```
 
+When using dynamic arguments calling `show` multiple times will result in the alert being updated. It will retain its position in the array of alerts.
+
+### Hybrid alerts
+
 The two approaches can also be combined, i.e. having a static `message` and dynamic `options` or vice versa.
 
-## Usage note
+## Usage of the returned `hide` function
 
-The app-shell wraps the app in an `AlertsProvider` and also includes an `Alerts` component which leverages `useAlerts` to show `AlertBars` in an `AlertStack` (`@dhis2/ui` components). So in a typical DHIS2 app the only thing you need to use from the alerts-service is the `useAlert` hook.
+`hide() -> void`
+
+Calling `hide` will immediately remove the alert from the list of alerts in the context.
+
+If `hide` is called before `show` this is a no-op. When first calling `show`, then `hide` and then `show` the alert will re-appear, but it will have a different position in the alerts array because it gets added to the end.

--- a/docs/hooks/useAlerts.md
+++ b/docs/hooks/useAlerts.md
@@ -2,23 +2,37 @@
 
 `useAlerts() → Alert[]`
 
-## Usage note
-
-The app-shell wraps the app in an `AlertsProvider` and also includes an `Alerts` component which leverages `useAlerts` to show `AlertBars` in an `AlertStack` (`@dhis2/ui` components). So in a typical DHIS2 app the only thing you need to use from the alerts-service is the `useAlert` hook.
-
 ## Alert
 
-| Prop      | Type       | Description                                                                                                                                            |
-| --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `message` | `string`   | The alert message to display                                                                                                                           |
-| `id`      | `number`   | Can be used as `key` when mapping over `alerts`                                                                                                        |
-| `remove`  | `function` | Call this to remove the `alert`                                                                                                                        |
-| `options` | `object`   | A configuration object that matches [the props](https://ui.dhis2.nu/#/api?id=coresrcalertbaralertbarproptypes-object) of the `AlertBar` in `@dhis2/ui` |
+| Prop      | Type       | Description                                                                                                                                                                      |
+| --------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `message` | `string`   | The alert message to display                                                                                                                                                     |
+| `id`      | `number`   | Can be used as `key` when mapping over `alerts`                                                                                                                                  |
+| `remove`  | `function` | Call this to remove the `alert`                                                                                                                                                  |
+| `options` | `object`   | A configuration object that matches the props of the alert component, for example [a @dhis2/ui `AlertBar`](https://ui.dhis2.nu/#/api?id=coresrcalertbaralertbarproptypes-object) |
 
-## Example
+## Usage note
+
+The DHIS2 app-shell wraps the app in an `AlertsProvider` and also includes an `Alerts` component which leverages `useAlerts` to show `AlertBars` in an `AlertStack` (`@dhis2/ui` components). So in a typical DHIS2 app the only hook used from the alerts-service is `useAlert`.
+
+## Standalone example
+
+Below is a very basic example of how a non-platform app could use the alerts-service provider and hooks. For a more advanced implementation of a component that displays alerts with a hide/show animation, see [here](https://github.com/dhis2/app-platform/blob/master/adapter/src/components/Alerts.js).
 
 ```js
-export const Alerts = () => {
+import { AlertsProvider, useAlert, useAlerts } from '@dhis2/alerts-service'
+
+const Alerter = () => {
+    const { show, hide } = useAlert('Hello world')
+
+    return (
+        <>
+            <button onClick={show}>Show</button>
+            <button onClick={hide}>Hide</button>
+        </>
+    )
+}
+const Alerts = () => {
     const alerts = useAlerts()
 
     return alerts.map(alert => (
@@ -28,4 +42,11 @@ export const Alerts = () => {
         </div>
     ))
 }
+
+const App = () => (
+    <AlertsProvider>
+        <Alerter />
+        <Alerts />
+    </AlertsProvider>
+)
 ```

--- a/examples/cra/src/components/Alerts.js
+++ b/examples/cra/src/components/Alerts.js
@@ -7,14 +7,7 @@ export const Alerts = () => {
     return alerts.map(alert => (
         <div key={alert.id}>
             {alert.message}
-            <button
-                onClick={() => {
-                    alert.options.onHidden && alert.options.onHidden()
-                    alert.remove()
-                }}
-            >
-                hide
-            </button>
+            <button onClick={alert.remove}>hide</button>
         </div>
     ))
 }

--- a/examples/cra/yarn.lock
+++ b/examples/cra/yarn.lock
@@ -1054,26 +1054,26 @@
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@dhis2/app-runtime@file:../../runtime":
-  version "2.9.0-beta.7"
+  version "3.0.0"
   dependencies:
-    "@dhis2/app-service-alerts" "2.9.0-beta.7"
-    "@dhis2/app-service-config" "2.9.0-beta.7"
-    "@dhis2/app-service-data" "2.9.0-beta.7"
-    "@dhis2/app-service-offline" "2.11.0"
+    "@dhis2/app-service-alerts" "3.0.0"
+    "@dhis2/app-service-config" "3.0.0"
+    "@dhis2/app-service-data" "3.0.0"
+    "@dhis2/app-service-offline" "3.0.0"
 
-"@dhis2/app-service-alerts@2.9.0-beta.7", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "2.9.0-beta.7"
+"@dhis2/app-service-alerts@3.0.0", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.0.0"
 
-"@dhis2/app-service-config@2.9.0-beta.7", "@dhis2/app-service-config@file:../../services/config":
-  version "2.9.0-beta.7"
+"@dhis2/app-service-config@3.0.0", "@dhis2/app-service-config@file:../../services/config":
+  version "3.0.0"
 
-"@dhis2/app-service-data@2.9.0-beta.7", "@dhis2/app-service-data@file:../../services/data":
-  version "2.9.0-beta.7"
+"@dhis2/app-service-data@3.0.0", "@dhis2/app-service-data@file:../../services/data":
+  version "3.0.0"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@2.11.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "2.11.0"
+"@dhis2/app-service-offline@3.0.0", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.0.0"
   dependencies:
     lodash "^4.17.21"
 

--- a/examples/query-playground/yarn.lock
+++ b/examples/query-playground/yarn.lock
@@ -1789,36 +1789,27 @@
   dependencies:
     moment "^2.24.0"
 
-"@dhis2/app-runtime@*":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.8.0.tgz#83ca6e96c299686ee72eea3e1825e04aa53cd5d2"
-  integrity sha512-Ru6x9L61fD7ITzVaxFqx88kV5/ypB9xSr8nHgRj4EE/kHl/aVejXuwnSS2OIWh80J3mtD1dpNRN/GJ8o0x0HYg==
+"@dhis2/app-runtime@*", "@dhis2/app-runtime@^2.2.2", "@dhis2/app-runtime@file:../../runtime":
+  version "3.0.0"
   dependencies:
-    "@dhis2/app-service-alerts" "2.8.0"
-    "@dhis2/app-service-config" "2.8.0"
-    "@dhis2/app-service-data" "2.8.0"
+    "@dhis2/app-service-alerts" "3.0.0"
+    "@dhis2/app-service-config" "3.0.0"
+    "@dhis2/app-service-data" "3.0.0"
+    "@dhis2/app-service-offline" "3.0.0"
 
-"@dhis2/app-runtime@^2.2.2", "@dhis2/app-runtime@file:../../runtime":
-  version "3.0.0-beta.2"
-  dependencies:
-    "@dhis2/app-service-alerts" "3.0.0-beta.2"
-    "@dhis2/app-service-config" "3.0.0-beta.2"
-    "@dhis2/app-service-data" "3.0.0-beta.2"
-    "@dhis2/app-service-offline" "3.0.0-beta.2"
+"@dhis2/app-service-alerts@3.0.0", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.0.0"
 
-"@dhis2/app-service-alerts@2.8.0", "@dhis2/app-service-alerts@3.0.0-beta.2", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.0.0-beta.2"
+"@dhis2/app-service-config@3.0.0", "@dhis2/app-service-config@file:../../services/config":
+  version "3.0.0"
 
-"@dhis2/app-service-config@2.8.0", "@dhis2/app-service-config@3.0.0-beta.2", "@dhis2/app-service-config@file:../../services/config":
-  version "3.0.0-beta.2"
-
-"@dhis2/app-service-data@2.8.0", "@dhis2/app-service-data@3.0.0-beta.2", "@dhis2/app-service-data@file:../../services/data":
-  version "3.0.0-beta.2"
+"@dhis2/app-service-data@3.0.0", "@dhis2/app-service-data@file:../../services/data":
+  version "3.0.0"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.0.0-beta.2", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.0.0-beta.2"
+"@dhis2/app-service-offline@3.0.0", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.0.0"
   dependencies:
     lodash "^4.17.21"
 

--- a/services/alerts/src/AlertsContext.ts
+++ b/services/alerts/src/AlertsContext.ts
@@ -1,4 +1,4 @@
 import React from 'react'
-import { AlertsManagerAlert } from './types'
+import type { Alert } from './types'
 
-export const AlertsContext = React.createContext<AlertsManagerAlert[]>([])
+export const AlertsContext = React.createContext<Alert[]>([])

--- a/services/alerts/src/AlertsManagerContext.ts
+++ b/services/alerts/src/AlertsManagerContext.ts
@@ -1,11 +1,15 @@
 import React from 'react'
-import { AlertsManager } from './types'
+import type { AlertsManager } from './types'
 
-const noop = () => {
-    /* Do nothing */
+const placeholder = () => {
+    throw new Error(
+        'This function is a placeholder used when creating the AlertsManagerContext, it should be overridden'
+    )
 }
 
-const defaultAlertsManager: AlertsManager = { remove: noop, add: noop }
+const defaultAlertsManager: AlertsManager = {
+    add: placeholder,
+}
 
 export const AlertsManagerContext = React.createContext<AlertsManager>(
     defaultAlertsManager

--- a/services/alerts/src/AlertsProvider.tsx
+++ b/services/alerts/src/AlertsProvider.tsx
@@ -1,11 +1,15 @@
-import React, { useState } from 'react'
+import React, { ReactElement, useState } from 'react'
 import { AlertsContext } from './AlertsContext'
 import { AlertsManagerContext } from './AlertsManagerContext'
 import { makeAlertsManager } from './makeAlertsManager'
-import { AlertsManagerAlert, AlertsManager } from './types'
+import type { Alert, AlertsManager } from './types'
 
-export const AlertsProvider = ({ children }: { children: React.ReactNode }) => {
-    const [alerts, setAlerts] = useState<AlertsManagerAlert[]>([])
+export const AlertsProvider = ({
+    children,
+}: {
+    children: React.ReactNode
+}): ReactElement => {
+    const [alerts, setAlerts] = useState<Alert[]>([])
     const [alertsManager] = useState<AlertsManager>(() =>
         makeAlertsManager(setAlerts)
     )

--- a/services/alerts/src/__tests__/integration.test.tsx
+++ b/services/alerts/src/__tests__/integration.test.tsx
@@ -25,17 +25,14 @@ describe('useAlert and useAlerts used together', () => {
 
         const alert = result.current.alerts[0]
 
-        expect(alert).toEqual(
-            expect.objectContaining({
-                id: 1,
-                message: 'test',
-                options: {
-                    permanent: true,
-                },
-            })
-        )
-        expect(alert).toHaveProperty('remove')
-        expect(typeof alert.remove).toBe('function')
+        expect(alert).toEqual({
+            id: 1,
+            remove: expect.any(Function),
+            message: 'test',
+            options: {
+                permanent: true,
+            },
+        })
     })
 
     it('Can add an alert with dynamic arguments', () => {
@@ -64,29 +61,26 @@ describe('useAlert and useAlerts used together', () => {
 
         const alert = result.current.alerts[0]
 
-        expect(alert).toEqual(
-            expect.objectContaining({
-                id: 1,
-                message: 'Successfully deleted hendrik',
-                options: {
-                    critical: true,
-                },
-            })
-        )
-        expect(alert).toHaveProperty('remove')
-        expect(typeof alert.remove).toBe('function')
+        expect(alert).toEqual({
+            id: 1,
+            remove: expect.any(Function),
+            message: 'Successfully deleted hendrik',
+            options: {
+                critical: true,
+            },
+        })
     })
 
-    it('Can remove an alert', () => {
+    it('Can remove an alert with the hide function from useAlerts', () => {
         const wrapper = ({ children }: { children?: ReactNode }) => (
             <AlertsProvider>{children}</AlertsProvider>
         )
         const { result } = renderHook(
             () => {
                 const alerts = useAlerts()
-                const { show } = useAlert('test', { permanent: true })
+                const { show, hide } = useAlert('test', { permanent: true })
 
-                return { alerts, show }
+                return { alerts, show, hide }
             },
             { wrapper }
         )
@@ -96,6 +90,51 @@ describe('useAlert and useAlerts used together', () => {
         })
 
         expect(result.current.alerts).toHaveLength(1)
+
+        expect(result.current.alerts[0]).toEqual({
+            id: 1,
+            remove: expect.any(Function),
+            message: 'test',
+            options: {
+                permanent: true,
+            },
+        })
+
+        act(() => {
+            result.current.hide()
+        })
+
+        expect(result.current.alerts).toHaveLength(0)
+    })
+
+    it('Can remove an alert with the remove function on the alert itself', () => {
+        const wrapper = ({ children }: { children?: ReactNode }) => (
+            <AlertsProvider>{children}</AlertsProvider>
+        )
+        const { result } = renderHook(
+            () => {
+                const alerts = useAlerts()
+                const { show, hide } = useAlert('test', { permanent: true })
+
+                return { alerts, show, hide }
+            },
+            { wrapper }
+        )
+
+        act(() => {
+            result.current.show()
+        })
+
+        expect(result.current.alerts).toHaveLength(1)
+
+        expect(result.current.alerts[0]).toEqual({
+            id: 1,
+            remove: expect.any(Function),
+            message: 'test',
+            options: {
+                permanent: true,
+            },
+        })
 
         act(() => {
             result.current.alerts[0].remove()
@@ -128,7 +167,7 @@ describe('useAlert and useAlerts used together', () => {
         expect(hook.result.current.alerts).toHaveLength(1)
     })
 
-    it('Will create duplicate alerts when show is called multiple times in a render cycle', () => {
+    it('Will not create duplicate alerts when show is called multiple times in a render cycle', () => {
         const wrapper = ({ children }: { children?: ReactNode }) => (
             <AlertsProvider>{children}</AlertsProvider>
         )
@@ -147,7 +186,64 @@ describe('useAlert and useAlerts used together', () => {
             result.current.show()
         })
 
-        expect(result.current.alerts).toHaveLength(2)
+        expect(result.current.alerts).toHaveLength(1)
+    })
+
+    it('Will update the alert if show is called with different arguments', () => {
+        const wrapper = ({ children }: { children?: ReactNode }) => (
+            <AlertsProvider>{children}</AlertsProvider>
+        )
+        const { result } = renderHook(
+            () => {
+                const alerts = useAlerts()
+                const { show } = useAlert(
+                    ({ message }) => message,
+                    ({ options }) => options
+                )
+
+                return { alerts, show }
+            },
+            { wrapper }
+        )
+        // Show alert for first time
+        const payload1 = {
+            message: 'Message 1',
+            options: { permanent: true, critical: true },
+        }
+
+        act(() => {
+            result.current.show(payload1)
+        })
+
+        expect(result.current.alerts).toHaveLength(1)
+        expect(result.current.alerts[0]).toEqual({
+            ...payload1,
+            id: 1,
+            remove: expect.any(Function),
+            options: {
+                ...payload1.options,
+            },
+        })
+
+        // Show alert for second time
+        const payload2 = {
+            message: 'Message 2',
+            options: { success: true },
+        }
+
+        act(() => {
+            result.current.show(payload2)
+        })
+
+        expect(result.current.alerts).toHaveLength(1)
+        expect(result.current.alerts[0]).toEqual({
+            ...payload2,
+            id: 1,
+            remove: expect.any(Function),
+            options: {
+                ...payload2.options,
+            },
+        })
     })
 
     it('Will increment IDs when multiple alerts are added', () => {
@@ -186,30 +282,111 @@ describe('useAlert and useAlerts used together', () => {
         const { result } = renderHook(
             () => {
                 const alerts = useAlerts()
-                const { show: show1 } = useAlert('show 1')
-                const { show: show2 } = useAlert('show 2')
-                const { show: show3 } = useAlert('show 3')
+                const alert1 = useAlert('show 1')
+                const alert2 = useAlert('show 2')
+                const alert3 = useAlert('show 3')
 
-                return { alerts, show1, show2, show3 }
+                return { alerts, alert1, alert2, alert3 }
             },
             { wrapper }
         )
 
         act(() => {
-            result.current.show1()
-            result.current.show2()
-            result.current.show3()
+            result.current.alert1.show()
+            result.current.alert2.show()
+            result.current.alert3.show()
         })
 
         expect(result.current.alerts).toHaveLength(3)
 
         act(() => {
-            result.current.alerts[1].remove()
+            result.current.alert2.hide()
         })
 
         expect(result.current.alerts).toHaveLength(2)
 
         expect(result.current.alerts[0].id).toBe(1)
+        expect(result.current.alerts[1].id).toBe(3)
+    })
+
+    it('Gets added into a new slot when show is called after hide', () => {
+        const wrapper = ({ children }: { children?: ReactNode }) => (
+            <AlertsProvider>{children}</AlertsProvider>
+        )
+        const { result } = renderHook(
+            () => {
+                const alerts = useAlerts()
+                const alert1 = useAlert('show 1')
+                const alert2 = useAlert('show 2')
+
+                return { alerts, alert1, alert2 }
+            },
+            { wrapper }
+        )
+
+        act(() => {
+            result.current.alert1.show()
+            result.current.alert2.show()
+        })
+
+        expect(result.current.alerts).toHaveLength(2)
+        expect(result.current.alerts[0].id).toBe(1)
+        expect(result.current.alerts[1].id).toBe(2)
+
+        act(() => {
+            result.current.alert1.hide()
+        })
+
+        expect(result.current.alerts).toHaveLength(1)
+        expect(result.current.alerts[0].id).toBe(2)
+
+        act(() => {
+            result.current.alert1.show()
+        })
+
+        expect(result.current.alerts).toHaveLength(2)
+        expect(result.current.alerts[0].id).toBe(2)
+        // now is last item with id 3 because it was "re-added"
+        expect(result.current.alerts[1].id).toBe(3)
+    })
+    it('Gets added into a new slot when show is called after remove is called on an alert', () => {
+        const wrapper = ({ children }: { children?: ReactNode }) => (
+            <AlertsProvider>{children}</AlertsProvider>
+        )
+        const { result } = renderHook(
+            () => {
+                const alerts = useAlerts()
+                const alert1 = useAlert('show 1')
+                const alert2 = useAlert('show 2')
+
+                return { alerts, alert1, alert2 }
+            },
+            { wrapper }
+        )
+
+        act(() => {
+            result.current.alert1.show()
+            result.current.alert2.show()
+        })
+
+        expect(result.current.alerts).toHaveLength(2)
+        expect(result.current.alerts[0].id).toBe(1)
+        expect(result.current.alerts[1].id).toBe(2)
+
+        act(() => {
+            result.current.alerts[0].remove()
+        })
+
+        expect(result.current.alerts).toHaveLength(1)
+        expect(result.current.alerts[0].id).toBe(2)
+
+        act(() => {
+            result.current.alert1.show()
+        })
+
+        expect(result.current.alerts).toHaveLength(2)
+        expect(result.current.alerts[0].id).toBe(2)
+        // now is last item with id 3 because it was "re-added"
         expect(result.current.alerts[1].id).toBe(3)
     })
 })

--- a/services/alerts/src/__tests__/useAlert.test.tsx
+++ b/services/alerts/src/__tests__/useAlert.test.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from 'react'
 import { AlertsProvider, useAlert } from '../index'
 
 describe('useAlert', () => {
-    it('Renders without crashing', () => {
+    it('Hook returns a show and hide function', () => {
         const wrapper = ({ children }: { children?: ReactNode }) => (
             <AlertsProvider>{children}</AlertsProvider>
         )
@@ -11,5 +11,7 @@ describe('useAlert', () => {
 
         expect(result.current).toHaveProperty('show')
         expect(typeof result.current.show).toBe('function')
+        expect(result.current).toHaveProperty('hide')
+        expect(typeof result.current.hide).toBe('function')
     })
 })

--- a/services/alerts/src/types.ts
+++ b/services/alerts/src/types.ts
@@ -1,31 +1,18 @@
-type AlertAction = {
-    label: string
-    onClick: () => void
-}
-export type AlertOptions = {
-    actions?: AlertAction[]
-    className?: string
-    critical?: boolean
-    dataTest?: string
-    duration?: number
-    icon?: boolean | React.ElementType
-    permanent?: boolean
-    success?: boolean
-    warning?: boolean
-    onHidden?: () => void
-}
+import { MutableRefObject } from 'react'
 
-export interface AlertsManager {
-    add: (alert: Alert) => void
-    remove: (id: number) => void
-}
+export type AlertOptions = Record<string, unknown>
 
 export type Alert = {
+    id?: number
+    remove?: () => void
     message: string
     options: AlertOptions
 }
 
-export interface AlertsManagerAlert extends Alert {
-    id: number
-    remove: () => void
+export type AlertRef = MutableRefObject<Alert | null>
+
+export type AlertsMap = Map<number, Alert>
+
+export type AlertsManager = {
+    add: (alert: Alert, alertRef: AlertRef) => Alert
 }

--- a/services/alerts/src/useAlert.ts
+++ b/services/alerts/src/useAlert.ts
@@ -1,27 +1,39 @@
-import { useContext } from 'react'
+import { useContext, useRef, useCallback } from 'react'
 import { AlertsManagerContext } from './AlertsManagerContext'
-import { Alert, AlertOptions } from './types'
+import type { AlertOptions, Alert, AlertsManager } from './types'
 
 export const useAlert = (
     message: string | ((props: any) => string),
     options: AlertOptions | ((props: any) => AlertOptions) = {}
-) => {
-    const alertsManager = useContext(AlertsManagerContext)
+): { show: (props?: any) => void; hide: () => void } => {
+    const { add }: AlertsManager = useContext(AlertsManagerContext)
+    const alertRef = useRef(<Alert | null>null)
 
-    const show = (props?: any) => {
-        const resolvedMessage = String(
-            typeof message === 'function' ? message(props) : message
-        )
-        const resolvedOptions =
-            typeof options === 'function' ? options(props) : options
+    const show = useCallback(
+        (props?) => {
+            const resolvedMessage = String(
+                typeof message === 'function' ? message(props) : message
+            )
+            const resolvedOptions =
+                typeof options === 'function' ? options(props) : options
 
-        const alert: Alert = {
-            message: resolvedMessage,
-            options: resolvedOptions,
-        }
+            alertRef.current = add(
+                {
+                    message: resolvedMessage,
+                    options: resolvedOptions,
+                },
+                alertRef
+            )
+        },
+        [add, message, options]
+    )
 
-        alertsManager.add(alert)
+    const hide = useCallback(() => {
+        alertRef.current?.remove?.()
+    }, [])
+
+    return {
+        show,
+        hide,
     }
-
-    return { show }
 }

--- a/services/offline/src/__tests__/integration.test.tsx
+++ b/services/offline/src/__tests__/integration.test.tsx
@@ -1,3 +1,4 @@
+import { AlertsProvider } from '@dhis2/app-service-alerts'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import {
@@ -73,10 +74,12 @@ const TestSection = ({
 const TestSingleSection = (props?: any) => {
     // Props are spread so they can be overwritten
     return (
-        <OfflineProvider offlineInterface={mockOfflineInterface} {...props}>
-            <TestControls id={'1'} {...props} />
-            <TestSection id={'1'} {...props} />
-        </OfflineProvider>
+        <AlertsProvider>
+            <OfflineProvider offlineInterface={mockOfflineInterface} {...props}>
+                <TestControls id={'1'} {...props} />
+                <TestSection id={'1'} {...props} />
+            </OfflineProvider>
+        </AlertsProvider>
     )
 }
 
@@ -231,12 +234,14 @@ describe('Coordination between useCacheableSection and CacheableSection', () => 
 
 const TwoTestSections = (props?: any) => (
     // Props are spread so they can be overwritten (but only on one section)
-    <OfflineProvider offlineInterface={mockOfflineInterface} {...props}>
-        <TestControls id={'1'} {...props} />
-        <TestSection id={'1'} {...props} />
-        <TestControls id={'2'} />
-        <TestSection id={'2'} />
-    </OfflineProvider>
+    <AlertsProvider>
+        <OfflineProvider offlineInterface={mockOfflineInterface} {...props}>
+            <TestControls id={'1'} {...props} />
+            <TestSection id={'1'} {...props} />
+            <TestControls id={'2'} />
+            <TestSection id={'2'} />
+        </OfflineProvider>
+    </AlertsProvider>
 )
 
 // test that other sections don't rerender when one section does
@@ -285,11 +290,16 @@ describe('useCacheableSection can be used inside a child of CacheableSection', (
     const ChildTest = (props?: any) => {
         // Props are spread so they can be overwritten
         return (
-            <OfflineProvider offlineInterface={mockOfflineInterface} {...props}>
-                <TestSection id={'1'} {...props}>
-                    <TestControls id={'1'} {...props} />
-                </TestSection>
-            </OfflineProvider>
+            <AlertsProvider>
+                <OfflineProvider
+                    offlineInterface={mockOfflineInterface}
+                    {...props}
+                >
+                    <TestSection id={'1'} {...props}>
+                        <TestControls id={'1'} {...props} />
+                    </TestSection>
+                </OfflineProvider>
+            </AlertsProvider>
         )
     }
 

--- a/services/offline/src/lib/__tests__/offline-provider.test.tsx
+++ b/services/offline/src/lib/__tests__/offline-provider.test.tsx
@@ -1,3 +1,4 @@
+import { AlertsProvider } from '@dhis2/app-service-alerts'
 import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { mockOfflineInterface } from '../../utils/test-mocks'
@@ -26,16 +27,22 @@ afterEach(() => {
 describe('Testing offline provider', () => {
     it('Should render without failing', () => {
         render(
-            <OfflineProvider offlineInterface={mockOfflineInterface}>
-                <div data-testid="test-div" />
-            </OfflineProvider>
+            <AlertsProvider>
+                <OfflineProvider offlineInterface={mockOfflineInterface}>
+                    <div data-testid="test-div" />
+                </OfflineProvider>
+            </AlertsProvider>
         )
 
         expect(screen.getByTestId('test-div')).toBeInTheDocument()
     })
 
     it('Should initialize the offline interface with an update prompt', () => {
-        render(<OfflineProvider offlineInterface={mockOfflineInterface} />)
+        render(
+            <AlertsProvider>
+                <OfflineProvider offlineInterface={mockOfflineInterface} />
+            </AlertsProvider>
+        )
 
         expect(mockOfflineInterface.init).toHaveBeenCalledTimes(1)
 
@@ -64,9 +71,11 @@ describe('Testing offline provider', () => {
         }
 
         render(
-            <OfflineProvider offlineInterface={testOfflineInterface}>
-                <CachedSections />
-            </OfflineProvider>
+            <AlertsProvider>
+                <OfflineProvider offlineInterface={testOfflineInterface}>
+                    <CachedSections />
+                </OfflineProvider>
+            </AlertsProvider>
         )
 
         const { getByTestId } = screen
@@ -93,9 +102,11 @@ describe('Testing offline provider', () => {
         }
 
         render(
-            <OfflineProvider offlineInterface={mockOfflineInterface}>
-                <TestConsumer />
-            </OfflineProvider>
+            <AlertsProvider>
+                <OfflineProvider offlineInterface={mockOfflineInterface}>
+                    <TestConsumer />
+                </OfflineProvider>
+            </AlertsProvider>
         )
 
         expect(screen.getByTestId('test-div')).toBeInTheDocument()
@@ -103,9 +114,11 @@ describe('Testing offline provider', () => {
 
     it('Should render without failing when no offlineInterface is provided', () => {
         render(
-            <OfflineProvider>
-                <div data-testid="test-div" />
-            </OfflineProvider>
+            <AlertsProvider>
+                <OfflineProvider>
+                    <div data-testid="test-div" />
+                </OfflineProvider>
+            </AlertsProvider>
         )
         expect(screen.getByTestId('test-div')).toBeInTheDocument()
     })
@@ -116,9 +129,11 @@ describe('Testing offline provider', () => {
             pwaEnabled: false,
         }
         render(
-            <OfflineProvider offlineInterface={testOfflineInterface}>
-                <div data-testid="test-div" />
-            </OfflineProvider>
+            <AlertsProvider>
+                <OfflineProvider offlineInterface={testOfflineInterface}>
+                    <div data-testid="test-div" />
+                </OfflineProvider>
+            </AlertsProvider>
         )
 
         // Init should still be called - see comments in offline-provider.js

--- a/services/offline/src/lib/__tests__/use-cacheable-section.test.tsx
+++ b/services/offline/src/lib/__tests__/use-cacheable-section.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/display-name, react/prop-types */
 
+import { AlertsProvider } from '@dhis2/app-service-alerts'
 import { renderHook, act } from '@testing-library/react-hooks'
 import React from 'react'
 import {
@@ -31,9 +32,11 @@ afterEach(() => {
 it('renders in the default state initially', () => {
     const { result } = renderHook(() => useCacheableSection('one'), {
         wrapper: ({ children }) => (
-            <OfflineProvider offlineInterface={mockOfflineInterface}>
-                {children}
-            </OfflineProvider>
+            <AlertsProvider>
+                <OfflineProvider offlineInterface={mockOfflineInterface}>
+                    {children}
+                </OfflineProvider>
+            </AlertsProvider>
         ),
     })
 
@@ -57,9 +60,11 @@ it('handles a successful recording', async done => {
         () => useCacheableSection(sectionId),
         {
             wrapper: ({ children }) => (
-                <OfflineProvider offlineInterface={testOfflineInterface}>
-                    {children}
-                </OfflineProvider>
+                <AlertsProvider>
+                    <OfflineProvider offlineInterface={testOfflineInterface}>
+                        {children}
+                    </OfflineProvider>
+                </AlertsProvider>
             ),
         }
     )
@@ -121,9 +126,11 @@ it('handles a recording that encounters an error', async done => {
     }
     const { result } = renderHook(() => useCacheableSection('one'), {
         wrapper: ({ children }) => (
-            <OfflineProvider offlineInterface={testOfflineInterface}>
-                {children}
-            </OfflineProvider>
+            <AlertsProvider>
+                <OfflineProvider offlineInterface={testOfflineInterface}>
+                    {children}
+                </OfflineProvider>
+            </AlertsProvider>
         ),
     })
 
@@ -166,9 +173,11 @@ it('handles an error starting the recording', async () => {
     }
     const { result } = renderHook(() => useCacheableSection('err'), {
         wrapper: ({ children }) => (
-            <OfflineProvider offlineInterface={testOfflineInterface}>
-                {children}
-            </OfflineProvider>
+            <AlertsProvider>
+                <OfflineProvider offlineInterface={testOfflineInterface}>
+                    {children}
+                </OfflineProvider>
+            </AlertsProvider>
         ),
     })
 
@@ -192,9 +201,11 @@ it('handles remove and updates sections', async () => {
         () => useCacheableSection(sectionId),
         {
             wrapper: ({ children }) => (
-                <OfflineProvider offlineInterface={testOfflineInterface}>
-                    {children}
-                </OfflineProvider>
+                <AlertsProvider>
+                    <OfflineProvider offlineInterface={testOfflineInterface}>
+                        {children}
+                    </OfflineProvider>
+                </AlertsProvider>
             ),
         }
     )
@@ -228,9 +239,11 @@ it('handles a change in ID', async () => {
         (...args) => useCacheableSection(...args),
         {
             wrapper: ({ children }) => (
-                <OfflineProvider offlineInterface={testOfflineInterface}>
-                    {children}
-                </OfflineProvider>
+                <AlertsProvider>
+                    <OfflineProvider offlineInterface={testOfflineInterface}>
+                        {children}
+                    </OfflineProvider>
+                </AlertsProvider>
             ),
             initialProps: 'id-one',
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,21 +2181,7 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@*":
-  version "7.29.6"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.6.tgz#eb37844fb431186db7960a7ff6749ea65a19617c"
-  integrity sha512-vzTsAXa439ptdvav/4lsKRcGpAQX7b6wBIqia7+iNzqGJ5zjswApxA6jDAsexrc6ue9krWcbh8o+LYkBXW+GCQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.4"
-    lz-string "^1.4.4"
-    pretty-format "^26.6.2"
-
-"@testing-library/dom@^8.0.0":
+"@testing-library/dom@*", "@testing-library/dom@^8.0.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.1.0.tgz#f8358b1883844ea569ba76b7e94582168df5370d"
   integrity sha512-kmW9alndr19qd6DABzQ978zKQ+J65gU2Rzkl8hriIetPnwpesRaK4//jEQyYh8fEALmGhomD/LBQqt+o+DL95Q==
@@ -2447,15 +2433,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
-  integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=16.9.0":
+"@types/react@*", "@types/react@>=16.9.0":
   version "17.0.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.14.tgz#f0629761ca02945c4e8fea99b8177f4c5c61fb0f"
   integrity sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==
@@ -4366,12 +4344,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.6:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
-
-classnames@^2.3.1:
+classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -5583,12 +5556,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
-  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
-
-dom-accessibility-api@^0.5.6:
+dom-accessibility-api@^0.5.4, dom-accessibility-api@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz#3f5d43b52c7a3bd68b5fb63fa47b4e4c1fdf65a9"
   integrity sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==


### PR DESCRIPTION
There was one point in the design specs I previously missed, which requires us to enable developers to programatically hide alerts:
> Warning alerts do not dismiss automatically. They *disappear if the warning conditions change* (eg. the data that wasn't loading finishes loading) or the user dismisses them _([reference](https://github.com/dhis2/design-system/blob/master/molecules/alertbar.md#warning))_

I think it could be good to discuss this PR in a call. There are a few debatable aspects to this:
- Each call to `useAlert` now corresponds to a single alert-component. Calling `show` multiple times does not show a new alert-component. However, the corresponding alert can be updated by calling `show` again with different props. I think this is more predictable behaviour, but different from what we were doing before.
- This service was never 100% decoupled from the app-shell and the alert-bar implementation in ui-core, but the current PR makes things a lot worse. It's still possible to use the alert-service in a standalone project, but there are pretty strict instruction that would need to be followed (see changes to docs). I'm not 100% sure we want to actually expose this as a standalone service. I feel it might actually make more sense to just let this all be internal to the `@dhis2/app-adapter` package (and expose the `useAlert` hook from there?).

I'm looking forward to finding out what you think.

