### PR TITLE
feat(runtime): cache queries with react query

### DIFF
--- a/examples/cra/src/components/Alerts.js
+++ b/examples/cra/src/components/Alerts.js
@@ -9,6 +9,11 @@ export const Alerts = () => {
             {alert.message}
             <button
                 onClick={() => {
+                    /**
+                     * FIXME: the next line fails linting during the build, but can't
+                     * be disabled since it doesn't fail during linting when committing,
+                     * so eslint won't allow disabling it.
+                     */
                     alert.options.onHidden?.()
                     alert.remove()
                 }}

--- a/examples/cra/yarn.lock
+++ b/examples/cra/yarn.lock
@@ -995,6 +995,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
@@ -1047,20 +1054,22 @@
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@dhis2/app-runtime@file:../../runtime":
-  version "2.7.1"
+  version "2.8.0"
   dependencies:
-    "@dhis2/app-service-alerts" "2.7.1"
-    "@dhis2/app-service-config" "2.7.1"
-    "@dhis2/app-service-data" "2.7.1"
+    "@dhis2/app-service-alerts" "2.8.0"
+    "@dhis2/app-service-config" "2.8.0"
+    "@dhis2/app-service-data" "2.8.0"
 
-"@dhis2/app-service-alerts@2.7.1", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "2.7.1"
+"@dhis2/app-service-alerts@2.8.0", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "2.8.0"
 
-"@dhis2/app-service-config@2.7.1", "@dhis2/app-service-config@file:../../services/config":
-  version "2.7.1"
+"@dhis2/app-service-config@2.8.0", "@dhis2/app-service-config@file:../../services/config":
+  version "2.8.0"
 
-"@dhis2/app-service-data@2.7.1", "@dhis2/app-service-data@file:../../services/data":
-  version "2.7.1"
+"@dhis2/app-service-data@2.8.0", "@dhis2/app-service-data@file:../../services/data":
+  version "2.8.0"
+  dependencies:
+    react-query "^3.13.11"
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -2244,6 +2253,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2344,6 +2358,20 @@ braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -3526,6 +3554,11 @@ detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+
+detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 detect-port-alt@1.1.6:
   version "1.1.6"
@@ -6115,6 +6148,11 @@ jest@24.9.0:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6575,6 +6613,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -6676,6 +6722,11 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -6870,6 +6921,13 @@ nan@^2.12.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -7160,6 +7218,11 @@ object.values@^1.1.0, object.values@^1.1.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -8594,6 +8657,15 @@ react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-query@^3.13.11:
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.18.1.tgz#893b5475a7b4add099e007105317446f7a2cd310"
+  integrity sha512-17lv3pQxU9n+cB5acUv0/cxNTjo9q8G+RsedC6Ax4V9D8xEM7Q5xf9xAbCPdEhDrrnzPjTls9fQEABKRSi7OJA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-scripts@^3.3.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-3.4.1.tgz#f551298b5c71985cc491b9acf3c8e8c0ae3ada0a"
@@ -8840,6 +8912,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -9038,6 +9115,13 @@ rimraf@2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -10235,6 +10319,14 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/examples/query-playground/yarn.lock
+++ b/examples/query-playground/yarn.lock
@@ -1682,6 +1682,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1783,20 +1790,22 @@
     moment "^2.24.0"
 
 "@dhis2/app-runtime@*", "@dhis2/app-runtime@^2.2.2", "@dhis2/app-runtime@file:../../runtime":
-  version "2.7.1"
+  version "2.8.0"
   dependencies:
-    "@dhis2/app-service-alerts" "2.7.1"
-    "@dhis2/app-service-config" "2.7.1"
-    "@dhis2/app-service-data" "2.7.1"
+    "@dhis2/app-service-alerts" "2.8.0"
+    "@dhis2/app-service-config" "2.8.0"
+    "@dhis2/app-service-data" "2.8.0"
 
-"@dhis2/app-service-alerts@2.7.1", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "2.7.1"
+"@dhis2/app-service-alerts@2.8.0", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "2.8.0"
 
-"@dhis2/app-service-config@2.7.1", "@dhis2/app-service-config@file:../../services/config":
-  version "2.7.1"
+"@dhis2/app-service-config@2.8.0", "@dhis2/app-service-config@file:../../services/config":
+  version "2.8.0"
 
-"@dhis2/app-service-data@2.7.1", "@dhis2/app-service-data@file:../../services/data":
-  version "2.7.1"
+"@dhis2/app-service-data@2.8.0", "@dhis2/app-service-data@file:../../services/data":
+  version "2.8.0"
+  dependencies:
+    react-query "^3.13.11"
 
 "@dhis2/app-shell@5.2.0":
   version "5.2.0"
@@ -3344,6 +3353,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -3467,6 +3481,20 @@ braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -4869,6 +4897,11 @@ detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+
+detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 detect-port-alt@1.1.6:
   version "1.1.6"
@@ -7784,6 +7817,11 @@ jest@24.9.0:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -8354,6 +8392,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -8455,6 +8501,11 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -8693,6 +8744,13 @@ nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^2.1.6:
   version "2.1.11"
@@ -9009,6 +9067,11 @@ object.values@^1.1.0, object.values@^1.1.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -10610,6 +10673,15 @@ react-popper@^2.2.3:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
+react-query@^3.13.11:
+  version "3.18.1"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.18.1.tgz#893b5475a7b4add099e007105317446f7a2cd310"
+  integrity sha512-17lv3pQxU9n+cB5acUv0/cxNTjo9q8G+RsedC6Ax4V9D8xEM7Q5xf9xAbCPdEhDrrnzPjTls9fQEABKRSi7OJA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-scripts@^3.3.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-3.4.1.tgz#f551298b5c71985cc491b9acf3c8e8c0ae3ada0a"
@@ -10869,6 +10941,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-bom-buffer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz#c2bf1e377520d324f623892e33c10cac2c252b53"
@@ -11100,6 +11177,13 @@ rimraf@2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -12574,6 +12658,14 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@dhis2/cli-style": "^7.2.2",
         "@dhis2/cli-utils-docsite": "^2.0.3",
         "@testing-library/jest-dom": "^5.0.2",
-        "@testing-library/react": "^9.4.0",
+        "@testing-library/react": "^10.0.0",
         "@testing-library/react-hooks": "^3.2.1",
         "@types/jest": "^24.9.0",
         "@types/node": "^13.1.8",

--- a/services/data/package.json
+++ b/services/data/package.json
@@ -36,5 +36,8 @@
         "type-check:watch": "yarn type-check --watch",
         "test": "d2-app-scripts test",
         "coverage": "yarn test --coverage"
+    },
+    "dependencies": {
+        "react-query": "^3.13.11"
     }
 }

--- a/services/data/src/__tests__/integration.test.tsx
+++ b/services/data/src/__tests__/integration.test.tsx
@@ -1,23 +1,8 @@
 import { render, waitFor } from '@testing-library/react'
 import React, { ReactNode } from 'react'
-import { QueryClient, QueryClientProvider, setLogger } from 'react-query'
+import { setLogger } from 'react-query'
 import { CustomDataProvider, DataQuery } from '../react'
 import { QueryRenderInput } from '../types'
-
-// eslint-disable-next-line react/display-name
-const createWrapper = (mockData, queryClientOptions = {}) => ({
-    children,
-}: {
-    children?: ReactNode
-}) => {
-    const queryClient = new QueryClient(queryClientOptions)
-
-    return (
-        <QueryClientProvider client={queryClient}>
-            <CustomDataProvider data={mockData}>{children}</CustomDataProvider>
-        </QueryClientProvider>
-    )
-}
 
 beforeAll(() => {
     // Prevent the react-query logger from logging to the console
@@ -38,7 +23,9 @@ describe('Testing custom data provider and useQuery hook', () => {
         const data = {
             answer: 42,
         }
-        const wrapper = createWrapper(data)
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={data}>{children}</CustomDataProvider>
+        )
         const renderFunction = jest.fn(
             ({ loading, error, data }: QueryRenderInput) => {
                 if (loading) return 'loading'
@@ -88,14 +75,9 @@ describe('Testing custom data provider and useQuery hook', () => {
                 throw expectedError
             },
         }
-        // Disable automatic retries, see: https://react-query.tanstack.com/reference/useQuery
-        const wrapper = createWrapper(data, {
-            defaultOptions: {
-                queries: {
-                    retry: false,
-                },
-            },
-        })
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={data}>{children}</CustomDataProvider>
+        )
         const renderFunction = jest.fn(
             ({ loading, error, data }: QueryRenderInput) => {
                 if (loading) return 'loading'

--- a/services/data/src/__tests__/integration.test.tsx
+++ b/services/data/src/__tests__/integration.test.tsx
@@ -1,19 +1,44 @@
-import { render, waitForElement, act } from '@testing-library/react'
-import React from 'react'
-import {
-    FetchType,
-    DataEngineLinkExecuteOptions,
-    ResolvedResourceQuery,
-} from '../engine'
+import { render, waitFor } from '@testing-library/react'
+import React, { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider, setLogger } from 'react-query'
 import { CustomDataProvider, DataQuery } from '../react'
 import { QueryRenderInput } from '../types'
 
-const customData = {
-    answer: 42,
+// eslint-disable-next-line react/display-name
+const createWrapper = (mockData, queryClientOptions = {}) => ({
+    children,
+}: {
+    children?: ReactNode
+}) => {
+    const queryClient = new QueryClient(queryClientOptions)
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <CustomDataProvider data={mockData}>{children}</CustomDataProvider>
+        </QueryClientProvider>
+    )
 }
+
+beforeAll(() => {
+    // Prevent the react-query logger from logging to the console
+    setLogger({
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    })
+})
+
+afterAll(() => {
+    // Restore the original react-query logger
+    setLogger(console)
+})
 
 describe('Testing custom data provider and useQuery hook', () => {
     it('Should render without failing', async () => {
+        const data = {
+            answer: 42,
+        }
+        const wrapper = createWrapper(data)
         const renderFunction = jest.fn(
             ({ loading, error, data }: QueryRenderInput) => {
                 if (loading) return 'loading'
@@ -23,37 +48,54 @@ describe('Testing custom data provider and useQuery hook', () => {
         )
 
         const { getByText } = render(
-            <CustomDataProvider data={customData}>
-                <DataQuery query={{ answer: { resource: 'answer' } }}>
-                    {renderFunction}
-                </DataQuery>
-            </CustomDataProvider>
+            <DataQuery query={{ answer: { resource: 'answer' } }}>
+                {renderFunction}
+            </DataQuery>,
+            { wrapper }
         )
 
         expect(getByText(/loading/i)).not.toBeUndefined()
         expect(renderFunction).toHaveBeenCalledTimes(1)
         expect(renderFunction).toHaveBeenLastCalledWith({
             called: true,
+            data: undefined,
+            engine: expect.any(Object),
+            error: undefined,
             loading: true,
             refetch: expect.any(Function),
-            engine: expect.any(Object),
         })
-        await waitForElement(() => getByText(/data: /i))
+
+        await waitFor(() => {
+            getByText(/data: /i)
+        })
+
+        expect(getByText(/data: /i)).toHaveTextContent(`data: ${data.answer}`)
         expect(renderFunction).toHaveBeenCalledTimes(2)
         expect(renderFunction).toHaveBeenLastCalledWith({
             called: true,
-            loading: false,
-            data: customData,
-            refetch: expect.any(Function),
+            data,
             engine: expect.any(Object),
+            error: undefined,
+            loading: false,
+            refetch: expect.any(Function),
         })
-
-        expect(getByText(/data: /i)).toHaveTextContent(
-            `data: ${customData.answer}`
-        )
     })
 
     it('Should render an error', async () => {
+        const expectedError = new Error('Something went wrong')
+        const data = {
+            test: () => {
+                throw expectedError
+            },
+        }
+        // Disable automatic retries, see: https://react-query.tanstack.com/reference/useQuery
+        const wrapper = createWrapper(data, {
+            defaultOptions: {
+                queries: {
+                    retry: false,
+                },
+            },
+        })
         const renderFunction = jest.fn(
             ({ loading, error, data }: QueryRenderInput) => {
                 if (loading) return 'loading'
@@ -63,120 +105,38 @@ describe('Testing custom data provider and useQuery hook', () => {
         )
 
         const { getByText } = render(
-            <CustomDataProvider data={customData}>
-                <DataQuery query={{ test: { resource: 'test' } }}>
-                    {renderFunction}
-                </DataQuery>
-            </CustomDataProvider>
+            <DataQuery query={{ test: { resource: 'test' } }}>
+                {renderFunction}
+            </DataQuery>,
+            { wrapper }
         )
 
         expect(getByText(/loading/i)).not.toBeUndefined()
         expect(renderFunction).toHaveBeenCalledTimes(1)
         expect(renderFunction).toHaveBeenLastCalledWith({
             called: true,
+            data: undefined,
+            engine: expect.any(Object),
+            error: undefined,
             loading: true,
             refetch: expect.any(Function),
+        })
+
+        await waitFor(() => {
+            getByText(/error: /i)
+        })
+
+        expect(renderFunction).toHaveBeenCalledTimes(2)
+        expect(getByText(/error: /i)).toHaveTextContent(
+            `error: ${expectedError.message}`
+        )
+        expect(renderFunction).toHaveBeenLastCalledWith({
+            called: true,
+            data: undefined,
             engine: expect.any(Object),
+            error: expectedError,
+            loading: false,
+            refetch: expect.any(Function),
         })
-        await waitForElement(() => getByText(/error: /i))
-        expect(renderFunction).toHaveBeenCalledTimes(2)
-        expect(String(renderFunction.mock.calls[1][0].error)).toBe(
-            'Error: No data provided for resource type test!'
-        )
-        // expect(getByText(/data: /i)).toHaveTextContent(
-        //     `data: ${customData.answer}`
-        // )
-    })
-
-    it('Should abort the fetch when unmounted', async () => {
-        const renderFunction = jest.fn(
-            ({ loading, error, data }: QueryRenderInput) => {
-                if (loading) return 'loading'
-                if (error) return <div>error: {error.message}</div>
-                return <div>data: {data && data.test}</div>
-            }
-        )
-
-        let signal: AbortSignal | null | undefined
-        const mockData = {
-            factory: jest.fn(
-                async (
-                    type: FetchType,
-                    _: ResolvedResourceQuery,
-                    options?: DataEngineLinkExecuteOptions
-                ) => {
-                    if (options && options.signal && !signal) {
-                        signal = options.signal
-                    }
-                    return 'done'
-                }
-            ),
-        }
-
-        const { unmount } = render(
-            <CustomDataProvider data={mockData}>
-                <DataQuery query={{ test: { resource: 'factory' } }}>
-                    {renderFunction}
-                </DataQuery>
-            </CustomDataProvider>
-        )
-
-        expect(renderFunction).toHaveBeenCalledTimes(1)
-        expect(mockData.factory).toHaveBeenCalledTimes(1)
-        act(() => {
-            unmount()
-        })
-        expect(signal && signal.aborted).toBe(true)
-    })
-
-    it('Should abort the fetch when refetching', async () => {
-        let refetch: any
-        const renderFunction = jest.fn(
-            ({ loading, error, data, refetch: _refetch }: QueryRenderInput) => {
-                refetch = _refetch
-                if (loading) return 'loading'
-                if (error) return <div>error: {error.message}</div>
-                return <div>data: {data && data.test}</div>
-            }
-        )
-
-        let signal: any
-        const mockData = {
-            factory: jest.fn(
-                async (
-                    type: FetchType,
-                    q: ResolvedResourceQuery,
-                    options?: DataEngineLinkExecuteOptions
-                ) => {
-                    if (options && options.signal && !signal) {
-                        signal = options.signal
-                    }
-                    return 'test'
-                }
-            ),
-        }
-
-        const { getByText } = render(
-            <CustomDataProvider data={mockData}>
-                <DataQuery query={{ test: { resource: 'factory' } }}>
-                    {renderFunction}
-                </DataQuery>
-            </CustomDataProvider>
-        )
-
-        expect(renderFunction).toHaveBeenCalledTimes(1)
-        expect(mockData.factory).toHaveBeenCalledTimes(1)
-
-        expect(signal.aborted).toBe(false)
-        expect(refetch).not.toBeUndefined()
-        act(() => {
-            refetch()
-        })
-
-        expect(signal.aborted).toBe(true)
-        await waitForElement(() => getByText(/data: /i))
-
-        expect(renderFunction).toHaveBeenCalledTimes(2)
-        expect(mockData.factory).toHaveBeenCalledTimes(2)
     })
 })

--- a/services/data/src/__tests__/mutations.test.tsx
+++ b/services/data/src/__tests__/mutations.test.tsx
@@ -1,4 +1,4 @@
-import { render, act, waitForElement } from '@testing-library/react'
+import { render, act, waitFor } from '@testing-library/react'
 import React from 'react'
 import { Mutation, FetchType, ResolvedResourceQuery, JsonMap } from '../engine'
 import { CustomDataProvider, DataMutation } from '../react'
@@ -71,7 +71,7 @@ describe('Test mutations', () => {
         ])
         expect(mockBackend.target).toHaveBeenCalledTimes(1)
 
-        await waitForElement(() => getByText(/data: /i))
+        await waitFor(() => getByText(/data: /i))
         expect(renderFunction).toHaveBeenCalledTimes(3)
         expect(renderFunction).toHaveBeenLastCalledWith([
             doMutation,

--- a/services/data/src/react/components/CustomDataProvider.tsx
+++ b/services/data/src/react/components/CustomDataProvider.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { QueryClient, QueryClientProvider } from 'react-query'
 import { DataEngine } from '../../engine'
 import { CustomDataLink, CustomData, CustomLinkOptions } from '../../links'
 import { DataContext } from '../context/DataContext'
@@ -7,17 +8,37 @@ interface CustomProviderInput {
     children: React.ReactNode
     data: CustomData
     options?: CustomLinkOptions
+    queryClientOptions?: any
 }
+
+/**
+ * Disable automatic retries, which can cause tests to take unnecessarily long
+ * see: https://react-query.tanstack.com/reference/useQuery
+ */
+const defaultQueryClientOptions = {
+    defaultOptions: {
+        queries: {
+            retry: false,
+        },
+    },
+}
+
 export const CustomDataProvider = ({
     children,
     data,
     options,
+    queryClientOptions = defaultQueryClientOptions,
 }: CustomProviderInput) => {
     const link = new CustomDataLink(data, options)
     const engine = new DataEngine(link)
-
+    const queryClient = new QueryClient(queryClientOptions)
     const context = { engine }
+
     return (
-        <DataContext.Provider value={context}>{children}</DataContext.Provider>
+        <QueryClientProvider client={queryClient}>
+            <DataContext.Provider value={context}>
+                {children}
+            </DataContext.Provider>
+        </QueryClientProvider>
     )
 }

--- a/services/data/src/react/components/DataProvider.tsx
+++ b/services/data/src/react/components/DataProvider.tsx
@@ -1,5 +1,6 @@
 import { useConfig } from '@dhis2/app-service-config'
 import React from 'react'
+import { QueryClient, QueryClientProvider } from 'react-query'
 import { DataEngine } from '../../engine'
 import { RestAPILink } from '../../links'
 import { DataContext } from '../context/DataContext'
@@ -9,6 +10,9 @@ export interface ProviderInput {
     apiVersion?: number
     children: React.ReactNode
 }
+
+const queryClient = new QueryClient()
+
 export const DataProvider = (props: ProviderInput) => {
     const config = {
         ...useConfig(),
@@ -17,12 +21,13 @@ export const DataProvider = (props: ProviderInput) => {
 
     const link = new RestAPILink(config)
     const engine = new DataEngine(link)
-
     const context = { engine }
 
     return (
-        <DataContext.Provider value={context}>
-            {props.children}
-        </DataContext.Provider>
+        <QueryClientProvider client={queryClient}>
+            <DataContext.Provider value={context}>
+                {props.children}
+            </DataContext.Provider>
+        </QueryClientProvider>
     )
 }

--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -1,66 +1,798 @@
 import { renderHook, act } from '@testing-library/react-hooks'
 import React, { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider, setLogger } from 'react-query'
 import { CustomDataProvider } from '../components/CustomDataProvider'
 import { useDataQuery } from './useDataQuery'
 
-const customData = {
-    answer: 42,
+// eslint-disable-next-line react/display-name
+const createWrapper = (mockData, queryClientOptions = {}) => ({
+    children,
+}: {
+    children?: ReactNode
+}) => {
+    const queryClient = new QueryClient(queryClientOptions)
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            <CustomDataProvider data={mockData}>{children}</CustomDataProvider>
+        </QueryClientProvider>
+    )
 }
 
-const wrapper = ({ children }: { children?: ReactNode }) => (
-    <CustomDataProvider data={customData}>{children}</CustomDataProvider>
-)
+beforeAll(() => {
+    // Prevent the react-query logger from logging to the console
+    setLogger({
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    })
+})
 
-const query = {
-    x: {
-        resource: 'answer',
-    },
-}
+afterAll(() => {
+    // Restore the original react-query logger
+    setLogger(console)
+})
+
 describe('useDataQuery', () => {
-    const originalError = console.error
+    describe('parameters: onComplete', () => {
+        it('Should call onComplete with the data after a successful fetch', async () => {
+            const query = { x: { resource: 'answer' } }
+            const mockData = { answer: 42 }
+            const wrapper = createWrapper(mockData)
+            const onComplete = jest.fn()
+            const onError = jest.fn()
 
-    afterEach(() => {
-        console.error = originalError
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { lazy: false, onComplete, onError }),
+                { wrapper }
+            )
+
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(onComplete).toHaveBeenCalledWith({ x: 42 })
+            expect(onError).not.toHaveBeenCalled()
+            expect(result.current).toMatchObject({
+                data: { x: 42 },
+            })
+        })
     })
 
-    it('Should render without failing', async () => {
-        let hookState: any
+    describe('parameters: onError', () => {
+        it('Should call onError with the error after a fetch error', async () => {
+            // Disable automatic retries, see: https://react-query.tanstack.com/reference/useQuery
+            const queryClientOptions = {
+                defaultOptions: {
+                    queries: {
+                        retry: false,
+                    },
+                },
+            }
 
-        console.error = jest.fn()
+            const expectedError = new Error('Something went wrong')
+            const query = { x: { resource: 'answer' } }
+            const mockData = {
+                answer: () => {
+                    throw expectedError
+                },
+            }
+            const wrapper = createWrapper(mockData, queryClientOptions)
+            const onComplete = jest.fn()
+            const onError = jest.fn()
 
-        act(() => {
-            hookState = renderHook(() => useDataQuery(query), {
-                wrapper,
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { onError, onComplete }),
+                { wrapper }
+            )
+
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(onError).toHaveBeenCalledWith(expectedError)
+            expect(onComplete).not.toHaveBeenCalled()
+            expect(result.current).toMatchObject({
+                error: expectedError,
+            })
+        })
+    })
+
+    describe('parameters: variables', () => {
+        it('Should ignore new variables from rerenders', async () => {
+            const one = 'one'
+            const two = 'two'
+            const resultOne = 1
+            const resultTwo = 2
+            const query = {
+                x: { resource: 'answer', id: ({ id }) => id },
+            }
+            const mockSpy = jest.fn((_, { id }) => {
+                switch (id) {
+                    case one:
+                        return resultOne
+                    case two:
+                        return resultTwo
+                }
+            })
+            const mockData = {
+                answer: mockSpy,
+            }
+            const wrapper = createWrapper(mockData)
+            const initialProps = {
+                query,
+                options: { variables: { id: one } },
+            }
+
+            const { result, waitForNextUpdate, rerender } = renderHook(
+                props => useDataQuery(props.query, props.options),
+                {
+                    wrapper,
+                    initialProps,
+                }
+            )
+
+            expect(mockSpy).toHaveBeenCalledTimes(1)
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(result.current).toMatchObject({
+                data: { x: resultOne },
+            })
+
+            act(() => {
+                const newProps = {
+                    query,
+                    options: {
+                        variables: { id: two },
+                    },
+                }
+
+                rerender(newProps)
+            })
+
+            expect(mockSpy).toHaveBeenCalledTimes(1)
+            expect(result.current).toMatchObject({
+                data: { x: resultOne },
+            })
+        })
+    })
+
+    describe('parameters: lazy', () => {
+        it('Should be false by default', async () => {
+            const query = { x: { resource: 'answer' } }
+            const mockSpy = jest.fn(() => 42)
+            const mockData = { answer: mockSpy }
+            const wrapper = createWrapper(mockData)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query),
+                { wrapper }
+            )
+
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(mockSpy).toHaveBeenCalledTimes(1)
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
+            })
+        })
+    })
+
+    describe('internal: caching', () => {
+        it('Should return stale data initially on refetch', async () => {
+            const answers = [42, 43]
+            const mockSpy = jest.fn(() => answers.shift())
+            const mockData = {
+                answer: mockSpy,
+            }
+            const query = { x: { resource: 'answer' } }
+            const wrapper = createWrapper(mockData)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query),
+                {
+                    wrapper,
+                }
+            )
+
+            expect(mockSpy).toHaveBeenCalledTimes(1)
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
+            })
+
+            act(() => {
+                result.current.refetch()
+            })
+
+            expect(mockSpy).toHaveBeenCalledTimes(2)
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
+            })
+
+            await waitForNextUpdate()
+
+            expect(mockSpy).toHaveBeenCalledTimes(2)
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 43 },
             })
         })
 
-        expect(hookState.result.current).toMatchObject({ loading: true })
+        it('Should return data from the cache if it is not stale', async () => {
+            // Keep cached data forever, see: https://react-query.tanstack.com/reference/useQuery
+            const queryClientOptions = {
+                defaultOptions: {
+                    queries: {
+                        staleTime: Infinity,
+                    },
+                },
+            }
+            const answers = [42, 43]
+            const mockSpy = jest.fn(() => answers.shift())
+            const mockData = {
+                answer: mockSpy,
+            }
+            const query = { x: { resource: 'answer' } }
+            const wrapper = createWrapper(mockData, queryClientOptions)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query),
+                {
+                    wrapper,
+                }
+            )
+
+            expect(mockSpy).toHaveBeenCalledTimes(1)
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            // Now the cache will contain a value for 'answer' without variables
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
+            })
+
+            act(() => {
+                // Add a variable to the request to ensure a different cache key
+                // eslint-disable-next-line
+                // @ts-ignore
+                result.current.refetch({ one: 1 })
+            })
+
+            expect(mockSpy).toHaveBeenCalledTimes(2)
+            expect(result.current).toMatchObject({
+                loading: true,
+            })
+
+            await waitForNextUpdate()
+
+            // Now the cache will contain a value for 'answer' with and without variables
+            expect(result.current).toMatchObject({
+                loading: false,
+                data: { x: 43 },
+            })
+
+            act(() => {
+                // Request the resource without variables again
+                // eslint-disable-next-line
+                // @ts-ignore
+                result.current.refetch({ one: undefined })
+            })
+
+            // This should return the resource from the cache without fetching
+            expect(mockSpy).toHaveBeenCalledTimes(2)
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
+            })
+        })
     })
 
-    it('Should lazily await a refetch call', async () => {
-        let hookState: any
+    describe('return values: data', () => {
+        it('Should return the data for a single resource query on success', async () => {
+            const query = { x: { resource: 'answer' } }
+            const mockData = { answer: 42 }
+            const wrapper = createWrapper(mockData)
 
-        console.error = jest.fn()
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query),
+                {
+                    wrapper,
+                }
+            )
 
-        act(() => {
-            hookState = renderHook(() => useDataQuery(query, { lazy: true }), {
-                wrapper,
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
             })
         })
 
-        expect(hookState.result.current).toMatchObject({ loading: false })
+        it('Should return the data for a multiple resource query on success', async () => {
+            const query = {
+                x: { resource: 'answer' },
+                y: { resource: 'opposite' },
+            }
+            const mockData = { answer: 42, opposite: 24 }
+            const wrapper = createWrapper(mockData)
 
-        act(() => {
-            hookState.result.current.refetch()
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query),
+                {
+                    wrapper,
+                }
+            )
+
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42, y: 24 },
+            })
+        })
+    })
+
+    describe('return values: error', () => {
+        it('Should return errors it encounters for a single resource query', async () => {
+            // Disable automatic retries, see: https://react-query.tanstack.com/reference/useQuery
+            const queryClientOptions = {
+                defaultOptions: {
+                    queries: {
+                        retry: false,
+                    },
+                },
+            }
+
+            const expectedError = new Error('Something went wrong')
+            const query = { x: { resource: 'answer' } }
+            const mockData = {
+                answer: () => {
+                    throw expectedError
+                },
+            }
+            const wrapper = createWrapper(mockData, queryClientOptions)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query),
+                {
+                    wrapper,
+                }
+            )
+
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                error: expectedError,
+            })
         })
 
-        expect(hookState.result.current).toMatchObject({ loading: true })
+        it('Should return errors it encounters for multiple resource queries', async () => {
+            // Disable automatic retries, see: https://react-query.tanstack.com/reference/useQuery
+            const queryClientOptions = {
+                defaultOptions: {
+                    queries: {
+                        retry: false,
+                    },
+                },
+            }
 
-        await hookState.waitForNextUpdate()
+            const expectedError = new Error('Something went wrong')
+            const query = {
+                x: { resource: 'answer' },
+                y: { resource: 'opposite' },
+            }
+            const mockData = {
+                answer: () => {
+                    throw expectedError
+                },
+                opposite: 24,
+            }
+            const wrapper = createWrapper(mockData, queryClientOptions)
 
-        expect(hookState.result.current).toMatchObject({
-            loading: false,
-            data: { x: 42 },
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query),
+                {
+                    wrapper,
+                }
+            )
+
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                error: expectedError,
+            })
+        })
+    })
+
+    describe('return values: refetch', () => {
+        it('Should not fetch until refetch has been called if lazy', async () => {
+            const query = { x: { resource: 'answer' } }
+            const mockSpy = jest.fn(() => 42)
+            const mockData = { answer: mockSpy }
+            const wrapper = createWrapper(mockData)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { lazy: true }),
+                { wrapper }
+            )
+
+            expect(mockSpy).toHaveBeenCalledTimes(0)
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: false,
+            })
+
+            act(() => {
+                result.current.refetch()
+            })
+
+            expect(mockSpy).toHaveBeenCalledTimes(1)
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitForNextUpdate()
+
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
+            })
+        })
+
+        it('Should call onComplete after a successful refetch', async () => {
+            const query = { x: { resource: 'answer' } }
+            const mockData = { answer: 42 }
+            const wrapper = createWrapper(mockData)
+            const onComplete = jest.fn()
+            const onError = jest.fn()
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { lazy: true, onComplete, onError }),
+                { wrapper }
+            )
+
+            act(() => {
+                result.current.refetch()
+            })
+
+            await waitForNextUpdate()
+
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
+            })
+            expect(onComplete).toHaveBeenCalledWith({ x: 42 })
+            expect(onError).not.toHaveBeenCalled()
+        })
+
+        it('Should call onError after a failed refetch', async () => {
+            // Disable automatic retries, see: https://react-query.tanstack.com/reference/useQuery
+            const queryClientOptions = {
+                defaultOptions: {
+                    queries: {
+                        retry: false,
+                    },
+                },
+            }
+
+            const expectedError = new Error('Something went wrong')
+            const query = { x: { resource: 'answer' } }
+            const mockData = {
+                answer: () => {
+                    throw expectedError
+                },
+            }
+            const wrapper = createWrapper(mockData, queryClientOptions)
+            const onComplete = jest.fn()
+            const onError = jest.fn()
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { lazy: true, onComplete, onError }),
+                { wrapper }
+            )
+
+            act(() => {
+                result.current.refetch()
+            })
+
+            await waitForNextUpdate()
+
+            expect(onError).toHaveBeenCalledWith(expectedError)
+            expect(onComplete).not.toHaveBeenCalled()
+            expect(result.current).toMatchObject({
+                error: expectedError,
+            })
+        })
+
+        it('Should return a promise that resolves with the data on success when refetching and lazy', async () => {
+            const query = { x: { resource: 'answer' } }
+            const mockData = { answer: 42 }
+            const wrapper = createWrapper(mockData)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { lazy: true }),
+                { wrapper }
+            )
+
+            let ourPromise
+            act(() => {
+                // This refetch will trigger our own refetch logic
+                ourPromise = result.current.refetch()
+            })
+
+            await waitForNextUpdate()
+
+            expect(ourPromise).resolves.toEqual({ x: 42 })
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
+            })
+        })
+
+        it('Should return a promise that resolves with the data on success when refetching and not lazy', async () => {
+            const query = { x: { resource: 'answer' } }
+            const mockData = { answer: 42 }
+            const wrapper = createWrapper(mockData)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { lazy: false }),
+                { wrapper }
+            )
+
+            let reactQueryPromise
+            act(() => {
+                // This refetch will trigger react query's refetch logic
+                reactQueryPromise = result.current.refetch()
+            })
+
+            await waitForNextUpdate()
+
+            expect(reactQueryPromise).resolves.toEqual({ x: 42 })
+            expect(result.current).toMatchObject({
+                loading: false,
+                called: true,
+                data: { x: 42 },
+            })
+        })
+
+        it('Should return a promise that does not reject on errors when refetching and lazy', async () => {
+            // Disable automatic retries, see: https://react-query.tanstack.com/reference/useQuery
+            const queryClientOptions = {
+                defaultOptions: {
+                    queries: {
+                        retry: false,
+                    },
+                },
+            }
+
+            const expectedError = new Error('Something went wrong')
+            const query = { x: { resource: 'answer' } }
+            const mockData = {
+                answer: () => {
+                    throw expectedError
+                },
+            }
+            const wrapper = createWrapper(mockData, queryClientOptions)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { lazy: true }),
+                { wrapper }
+            )
+
+            let ourPromise
+            act(() => {
+                // This refetch will trigger our own refetch logic
+                ourPromise = result.current.refetch()
+            })
+
+            await waitForNextUpdate()
+
+            expect(ourPromise).resolves.toBeUndefined()
+            expect(result.current).toMatchObject({
+                error: expectedError,
+            })
+        })
+
+        it('Should return a promise that does not reject on errors when refetching and not lazy', async () => {
+            // Disable automatic retries, see: https://react-query.tanstack.com/reference/useQuery
+            const queryClientOptions = {
+                defaultOptions: {
+                    queries: {
+                        retry: false,
+                    },
+                },
+            }
+
+            const expectedError = new Error('Something went wrong')
+            const query = { x: { resource: 'answer' } }
+            const mockData = {
+                answer: () => {
+                    throw expectedError
+                },
+            }
+            const wrapper = createWrapper(mockData, queryClientOptions)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { lazy: false }),
+                { wrapper }
+            )
+
+            let reactQueryPromise
+            act(() => {
+                // This refetch will trigger react query's refetch logic
+                reactQueryPromise = result.current.refetch()
+            })
+
+            await waitForNextUpdate()
+
+            expect(reactQueryPromise).resolves.toBeUndefined()
+            expect(result.current).toMatchObject({
+                error: expectedError,
+            })
+        })
+
+        it('Should accept new variables from refetch', async () => {
+            const one = 'one'
+            const two = 'two'
+            const resultOne = 1
+            const resultTwo = 2
+            const query = {
+                x: { resource: 'answer', id: ({ id }) => id },
+            }
+            const mockSpy = jest.fn((_, { id }) => {
+                switch (id) {
+                    case one:
+                        return resultOne
+                    case two:
+                        return resultTwo
+                }
+            })
+            const mockData = {
+                answer: mockSpy,
+            }
+            const wrapper = createWrapper(mockData)
+            const initialProps = {
+                query,
+                options: { variables: { id: one } },
+            }
+
+            const { result, waitForNextUpdate } = renderHook(
+                props => useDataQuery(props.query, props.options),
+                {
+                    wrapper,
+                    initialProps,
+                }
+            )
+
+            await waitForNextUpdate()
+
+            expect(result.current).toMatchObject({
+                data: { x: resultOne },
+            })
+
+            act(() => {
+                // eslint-disable-next-line
+                // @ts-ignore
+                result.current.refetch({ id: two })
+            })
+
+            await waitForNextUpdate()
+
+            expect(mockSpy).toHaveBeenCalledTimes(2)
+            expect(result.current).toMatchObject({
+                data: { x: resultTwo },
+            })
+        })
+
+        it('Should merge new variables from refetch with the existing variables', async () => {
+            const initialVariables = { one: 1, two: 2, three: 3 }
+            const newVariables = { two: 1, three: 1 }
+            const query = {
+                x: {
+                    resource: 'answer',
+                    params: ({ one, two, three }) => ({ one, two, three }),
+                },
+            }
+            const mockSpy = jest.fn(() => 42)
+            const mockData = {
+                answer: mockSpy,
+            }
+            const wrapper = createWrapper(mockData)
+
+            const { result, waitForNextUpdate } = renderHook(
+                () => useDataQuery(query, { variables: initialVariables }),
+                { wrapper }
+            )
+
+            await waitForNextUpdate()
+
+            // eslint-disable-next-line
+            // @ts-ignore
+            const { params: firstParams } = mockSpy.mock.calls[0][1]
+            expect(firstParams).toMatchObject(initialVariables)
+
+            act(() => {
+                // eslint-disable-next-line
+                // @ts-ignore
+                result.current.refetch(newVariables)
+            })
+
+            await waitForNextUpdate()
+
+            // eslint-disable-next-line
+            // @ts-ignore
+            const { params: secondParams } = mockSpy.mock.calls[1][1]
+            expect(secondParams).toMatchObject({
+                ...initialVariables,
+                ...newVariables,
+            })
         })
     })
 })

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -1,32 +1,121 @@
-import { useCallback } from 'react'
+import { useState, useRef } from 'react'
+import { useQuery } from 'react-query'
 import { Query, QueryOptions } from '../../engine'
-import { QueryRenderInput } from '../../types'
+import { FetchError } from '../../engine/types/FetchError'
+import { QueryRenderInput, QueryRefetchFunction } from '../../types'
 import { useDataEngine } from './useDataEngine'
-import { useQueryExecutor } from './useQueryExecutor'
 import { useStaticInput } from './useStaticInput'
 
-const empty = {}
 export const useDataQuery = (
     query: Query,
-    { onComplete, onError, variables = empty, lazy = false }: QueryOptions = {}
+    {
+        onComplete: userOnSuccess,
+        onError: userOnError,
+        variables: initialVariables = {},
+        lazy: initialLazy = false,
+    }: QueryOptions = {}
 ): QueryRenderInput => {
-    const engine = useDataEngine()
-    const [theQuery] = useStaticInput<Query>(query, {
+    const [variables, setVariables] = useState(initialVariables)
+    const [enabled, setEnabled] = useState(!initialLazy)
+    const [staticQuery] = useStaticInput<Query>(query, {
         warn: true,
         name: 'query',
     })
-    const execute = useCallback(options => engine.query(theQuery, options), [
-        engine,
-        theQuery,
-    ])
-    const { refetch, called, loading, error, data } = useQueryExecutor({
-        execute,
-        variables,
-        singular: true,
-        immediate: !lazy,
-        onComplete,
+
+    /**
+     * User callbacks and refetch handling
+     */
+
+    const refetchCallback = useRef<((data: any) => void) | null>(null)
+    const onSuccess = (data: any) => {
+        if (refetchCallback.current) {
+            refetchCallback.current(data)
+            refetchCallback.current = null
+        }
+
+        if (userOnSuccess) {
+            userOnSuccess(data)
+        }
+    }
+
+    const onError = (error: FetchError) => {
+        // If we'd want to reject on errors we'd call the cb with the error here
+        if (refetchCallback.current) {
+            refetchCallback.current = null
+        }
+
+        if (userOnError) {
+            userOnError(error)
+        }
+    }
+
+    /**
+     * Setting up react-query
+     */
+
+    const engine = useDataEngine()
+    const queryKey = [staticQuery, variables]
+    const queryFn = () => engine.query(staticQuery, { variables })
+
+    const {
+        isIdle,
+        isLoading: loading,
+        error,
+        data,
+        refetch: queryRefetch,
+    } = useQuery(queryKey, queryFn, {
+        enabled,
+        onSuccess,
         onError,
     })
 
-    return { engine, refetch, called, loading, error, data }
+    /**
+     * Refetch allows a user to update the variables or just
+     * trigger a refetch of the query with the current variables.
+     */
+
+    const refetch: QueryRefetchFunction = newVariables => {
+        /**
+         * If there are no updates that will trigger an automatic refetch
+         * we'll need to call react-query's refetch directly
+         */
+        if (enabled && !newVariables) {
+            return queryRefetch({
+                cancelRefetch: true,
+                throwOnError: false,
+            }).then(({ data }) => data)
+        }
+
+        if (!enabled) {
+            setEnabled(true)
+        }
+
+        if (newVariables) {
+            setVariables({ ...variables, ...newVariables })
+        }
+
+        // This promise does not currently reject on errors
+        return new Promise(resolve => {
+            refetchCallback.current = data => {
+                resolve(data)
+            }
+        })
+    }
+
+    /**
+     * react-query returns null or an error, but we return undefined
+     * or an error, so this ensures consistency with the other types.
+     */
+    const ourError = error || undefined
+    // A query is idle if it is lazy and no initial data is available.
+    const ourCalled = !isIdle
+
+    return {
+        engine,
+        called: ourCalled,
+        loading,
+        error: ourError,
+        data,
+        refetch,
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,6 +1132,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.3", "@babel/runtime@^7.6.2":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
+  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1909,16 +1916,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^25.5.0":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
-  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
-
 "@jest/types@^26.6.0", "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
@@ -2003,11 +2000,6 @@
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
-
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
-  integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -2160,18 +2152,19 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
-"@testing-library/dom@^6.15.0":
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.16.0.tgz#04ada27ed74ad4c0f0d984a1245bb29b1fd90ba9"
-  integrity sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==
+"@testing-library/dom@^7.22.3":
+  version "7.30.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.4.tgz#c6a4a91557e92035fd565246bbbfb8107aa4634d"
+  integrity sha512-GObDVMaI4ARrZEXaRy4moolNAxWPKvEYNV/fa6Uc2eAzR/t4otS6A7EhrntPBIQLeehL9DbVhscvvv7gd6hWqA==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    "@types/testing-library__dom" "^6.12.1"
-    aria-query "^4.0.2"
-    dom-accessibility-api "^0.3.0"
-    pretty-format "^25.1.0"
-    wait-for-expect "^3.0.2"
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
 
 "@testing-library/jest-dom@^5.0.2":
   version "5.11.9"
@@ -2195,14 +2188,13 @@
     "@babel/runtime" "^7.12.5"
     "@types/testing-library__react-hooks" "^3.4.0"
 
-"@testing-library/react@^9.4.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.5.0.tgz#71531655a7890b61e77a1b39452fbedf0472ca5e"
-  integrity sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==
+"@testing-library/react@^10.0.0":
+  version "10.4.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.4.9.tgz#9faa29c6a1a217bf8bbb96a28bd29d7a847ca150"
+  integrity sha512-pHZKkqUy0tmiD81afs8xfiuseXfU/N7rAX3iKjeZYje86t9VaB0LrxYVa+OOsvkrveX5jCK3IjajVn2MbePvqA==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@testing-library/dom" "^6.15.0"
-    "@types/testing-library__react" "^9.1.2"
+    "@babel/runtime" "^7.10.3"
+    "@testing-library/dom" "^7.22.3"
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -2382,13 +2374,6 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@types/react-dom@*":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.1.tgz#d92d77d020bfb083e07cc8e0ac9f933599a4d56a"
-  integrity sha512-yIVyopxQb8IDZ7SOHeTovurFq+fXiPICa+GV3gp0Xedsl+MwQlMLKmvrnEjFbQxjliH5YVAEWFh975eVNmKj7Q==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-dom@^16.9.5":
   version "16.9.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.11.tgz#752e223a1592a2c10f2668b215a0e0667f4faab1"
@@ -2446,19 +2431,12 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
 
-"@types/testing-library__dom@*", "@types/testing-library__dom@^7.5.0":
+"@types/testing-library__dom@^7.5.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-7.5.0.tgz#e0a00dd766983b1d6e9d10d33e708005ce6ad13e"
   integrity sha512-mj1aH4cj3XUpMEgVpognma5kHVtbm6U6cHZmEFzCRiXPvKkuHrFr3+yXdGLXvfFRBaQIVshPGHI+hGTOJlhS/g==
   dependencies:
     "@testing-library/dom" "*"
-
-"@types/testing-library__dom@^6.12.1":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
-  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
-  dependencies:
-    pretty-format "^24.3.0"
 
 "@types/testing-library__jest-dom@^5.9.1":
   version "5.9.5"
@@ -2473,15 +2451,6 @@
   integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
   dependencies:
     "@types/react-test-renderer" "*"
-
-"@types/testing-library__react@^9.1.2":
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.3.tgz#35eca61cc6ea923543796f16034882a1603d7302"
-  integrity sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==
-  dependencies:
-    "@types/react-dom" "*"
-    "@types/testing-library__dom" "*"
-    pretty-format "^25.1.0"
 
 "@types/uglify-js@*":
   version "3.12.0"
@@ -3137,7 +3106,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^4.0.2, aria-query@^4.2.2:
+aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
   integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
@@ -3706,6 +3675,11 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -3829,6 +3803,19 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.5.3.tgz#c75c39d923ae8af6284a893bfdc8bd3996d2dd2d"
+  integrity sha512-OLOXfwReZa2AAAh9yOUyiALB3YxBe0QpThwwuyRHLgpl8bSznSDmV6Mz7LeBJg1VZsMcDcNMy7B53w12qHrIhQ==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.0.4"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -5512,11 +5499,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dom-accessibility-api@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
-  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
 
 dom-accessibility-api@^0.5.4:
   version "0.5.4"
@@ -9049,6 +9031,11 @@ jest@^24.9.0:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -9797,6 +9784,14 @@ match-all@^1.2.5:
   resolved "https://registry.yarnpkg.com/match-all/-/match-all-1.2.6.tgz#66d276ad6b49655551e63d3a6ee53e8be0566f8d"
   integrity sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -9919,6 +9914,11 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.0.5"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -10168,6 +10168,13 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.20:
   version "3.1.20"
@@ -11774,7 +11781,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -11783,16 +11790,6 @@ pretty-format@^24.3.0, pretty-format@^24.9.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
-
-pretty-format@^25.1.0:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
-  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
-  dependencies:
-    "@jest/types" "^25.5.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
 
 pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
   version "26.6.2"
@@ -12104,7 +12101,7 @@ react-final-form@^6.5.1:
   dependencies:
     "@babel/runtime" "^7.12.1"
 
-react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -12121,6 +12118,15 @@ react-popper@^2.2.3:
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
+
+react-query@^3.13.11:
+  version "3.13.11"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.13.11.tgz#e63d4e1741450af4f227d0b14b8d72f13cfd170f"
+  integrity sha512-UVpCuXSEQ587DayD56nKTwJA+pjf5LVSwSHzWX6H9JYHJikAIy11R8S8UgQZVmNlWTsyaIzMwVFolbQJzpLc/A==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
 
 react-refresh@^0.8.3:
   version "0.8.3"
@@ -12461,6 +12467,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-bom-buffer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz#c2bf1e377520d324f623892e33c10cac2c252b53"
@@ -12729,17 +12740,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -14514,6 +14525,14 @@ unix-crypt-td-js@^1.1.4:
   resolved "https://registry.yarnpkg.com/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz#4912dfad1c8aeb7d20fa0a39e4c31918c1d5d5dd"
   integrity sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==
 
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -14784,11 +14803,6 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
-  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walk-back@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Implements client side caching with react-query (https://react-query.tanstack.com, https://react-query.tanstack.com/reference/useQuery). See https://jira.dhis2.org/browse/LIBS-166 for the related epic.

Todo:

- [x] Fix act warnings
- [x] Add tests to verify that caching is working as expected
- [x] Add a query cache provider
- [x] Update integration tests
- [x] Update example apps (if necessary)
- [x] Update CustomDataProvider to include a QueryClientProvider and accept queryClientOptions (disable automatic retries globally)
- [ ] Release first alpha

Follow-up:

- [ ] Finalize types
- [ ] Test in apps
- [ ] Update docs
- [ ] Address act warnings in the other tests
- [ ] Cancel requests (see [react-query's recommendations](https://react-query.tanstack.com/guides/query-cancellation))
- [ ] Address inefficient caching for queries that contains multiple queries. Could cache them separately with https://react-query.tanstack.com/reference/useQueries. Or warn.
- [ ] We could update our API so react-query's dependent queries can be used
- [ ] Consider our refetch API (we've discussed rethinking whether it should return a promise, whether that promise should reject, etc.)
- [ ] Take a look at our mutation hooks as well