### PR TITLE
feat(runtime): cache queries with useSWR

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@dhis2/cli-style": "^7.2.2",
         "@dhis2/cli-utils-docsite": "^2.0.3",
         "@testing-library/jest-dom": "^5.0.2",
-        "@testing-library/react": "^9.4.0",
+        "@testing-library/react": "^10.0.0",
         "@testing-library/react-hooks": "^3.2.1",
         "@types/jest": "^24.9.0",
         "@types/node": "^13.1.8",

--- a/services/data/package.json
+++ b/services/data/package.json
@@ -36,5 +36,8 @@
         "type-check:watch": "yarn type-check --watch",
         "test": "d2-app-scripts test",
         "coverage": "yarn test --coverage"
+    },
+    "dependencies": {
+        "swr": "^0.5.5"
     }
 }

--- a/services/data/src/__tests__/integration.test.tsx
+++ b/services/data/src/__tests__/integration.test.tsx
@@ -1,10 +1,6 @@
-import { render, waitForElement, act } from '@testing-library/react'
+import { render, waitFor, waitForElement } from '@testing-library/react'
 import React from 'react'
-import {
-    FetchType,
-    DataEngineLinkExecuteOptions,
-    ResolvedResourceQuery,
-} from '../engine'
+import { cache, SWRConfig } from 'swr'
 import { CustomDataProvider, DataQuery } from '../react'
 import { QueryRenderInput } from '../types'
 
@@ -13,6 +9,10 @@ const customData = {
 }
 
 describe('Testing custom data provider and useQuery hook', () => {
+    afterEach(async () => {
+        await waitFor(() => cache.clear())
+    })
+
     it('Should render without failing', async () => {
         const renderFunction = jest.fn(
             ({ loading, error, data }: QueryRenderInput) => {
@@ -23,37 +23,46 @@ describe('Testing custom data provider and useQuery hook', () => {
         )
 
         const { getByText } = render(
-            <CustomDataProvider data={customData}>
-                <DataQuery query={{ answer: { resource: 'answer' } }}>
-                    {renderFunction}
-                </DataQuery>
-            </CustomDataProvider>
+            <SWRConfig value={{ dedupingInterval: 0 }}>
+                <CustomDataProvider data={customData}>
+                    <DataQuery query={{ answer: { resource: 'answer' } }}>
+                        {renderFunction}
+                    </DataQuery>
+                </CustomDataProvider>
+            </SWRConfig>
         )
 
         expect(getByText(/loading/i)).not.toBeUndefined()
         expect(renderFunction).toHaveBeenCalledTimes(1)
         expect(renderFunction).toHaveBeenLastCalledWith({
             called: true,
+            data: undefined,
+            engine: expect.any(Object),
+            error: undefined,
             loading: true,
             refetch: expect.any(Function),
-            engine: expect.any(Object),
         })
-        await waitForElement(() => getByText(/data: /i))
+
+        await waitFor(() => {
+            getByText(/data: /i)
+        })
+
         expect(renderFunction).toHaveBeenCalledTimes(2)
         expect(renderFunction).toHaveBeenLastCalledWith({
             called: true,
-            loading: false,
             data: customData,
-            refetch: expect.any(Function),
             engine: expect.any(Object),
+            error: undefined,
+            loading: false,
+            refetch: expect.any(Function),
         })
-
         expect(getByText(/data: /i)).toHaveTextContent(
             `data: ${customData.answer}`
         )
     })
 
     it('Should render an error', async () => {
+        const expectedError = new Error('Something went wrong')
         const renderFunction = jest.fn(
             ({ loading, error, data }: QueryRenderInput) => {
                 if (loading) return 'loading'
@@ -61,122 +70,45 @@ describe('Testing custom data provider and useQuery hook', () => {
                 return <div>data: {data && data.test}</div>
             }
         )
+        const data = {
+            test: () => {
+                throw expectedError
+            },
+        }
 
         const { getByText } = render(
-            <CustomDataProvider data={customData}>
-                <DataQuery query={{ test: { resource: 'test' } }}>
-                    {renderFunction}
-                </DataQuery>
-            </CustomDataProvider>
+            <SWRConfig value={{ dedupingInterval: 0 }}>
+                <CustomDataProvider data={data}>
+                    <DataQuery query={{ test: { resource: 'test' } }}>
+                        {renderFunction}
+                    </DataQuery>
+                </CustomDataProvider>
+            </SWRConfig>
         )
 
         expect(getByText(/loading/i)).not.toBeUndefined()
         expect(renderFunction).toHaveBeenCalledTimes(1)
         expect(renderFunction).toHaveBeenLastCalledWith({
             called: true,
+            data: undefined,
+            engine: expect.any(Object),
+            error: undefined,
             loading: true,
             refetch: expect.any(Function),
+        })
+
+        await waitFor(() => {
+            getByText(/error: /i)
+        })
+
+        expect(renderFunction).toHaveBeenCalledTimes(2)
+        expect(renderFunction).toHaveBeenLastCalledWith({
+            called: true,
+            data: undefined,
             engine: expect.any(Object),
+            error: expectedError,
+            loading: false,
+            refetch: expect.any(Function),
         })
-        await waitForElement(() => getByText(/error: /i))
-        expect(renderFunction).toHaveBeenCalledTimes(2)
-        expect(String(renderFunction.mock.calls[1][0].error)).toBe(
-            'Error: No data provided for resource type test!'
-        )
-        // expect(getByText(/data: /i)).toHaveTextContent(
-        //     `data: ${customData.answer}`
-        // )
-    })
-
-    it('Should abort the fetch when unmounted', async () => {
-        const renderFunction = jest.fn(
-            ({ loading, error, data }: QueryRenderInput) => {
-                if (loading) return 'loading'
-                if (error) return <div>error: {error.message}</div>
-                return <div>data: {data && data.test}</div>
-            }
-        )
-
-        let signal: AbortSignal | null | undefined
-        const mockData = {
-            factory: jest.fn(
-                async (
-                    type: FetchType,
-                    _: ResolvedResourceQuery,
-                    options?: DataEngineLinkExecuteOptions
-                ) => {
-                    if (options && options.signal && !signal) {
-                        signal = options.signal
-                    }
-                    return 'done'
-                }
-            ),
-        }
-
-        const { unmount } = render(
-            <CustomDataProvider data={mockData}>
-                <DataQuery query={{ test: { resource: 'factory' } }}>
-                    {renderFunction}
-                </DataQuery>
-            </CustomDataProvider>
-        )
-
-        expect(renderFunction).toHaveBeenCalledTimes(1)
-        expect(mockData.factory).toHaveBeenCalledTimes(1)
-        act(() => {
-            unmount()
-        })
-        expect(signal && signal.aborted).toBe(true)
-    })
-
-    it('Should abort the fetch when refetching', async () => {
-        let refetch: any
-        const renderFunction = jest.fn(
-            ({ loading, error, data, refetch: _refetch }: QueryRenderInput) => {
-                refetch = _refetch
-                if (loading) return 'loading'
-                if (error) return <div>error: {error.message}</div>
-                return <div>data: {data && data.test}</div>
-            }
-        )
-
-        let signal: any
-        const mockData = {
-            factory: jest.fn(
-                async (
-                    type: FetchType,
-                    q: ResolvedResourceQuery,
-                    options?: DataEngineLinkExecuteOptions
-                ) => {
-                    if (options && options.signal && !signal) {
-                        signal = options.signal
-                    }
-                    return 'test'
-                }
-            ),
-        }
-
-        const { getByText } = render(
-            <CustomDataProvider data={mockData}>
-                <DataQuery query={{ test: { resource: 'factory' } }}>
-                    {renderFunction}
-                </DataQuery>
-            </CustomDataProvider>
-        )
-
-        expect(renderFunction).toHaveBeenCalledTimes(1)
-        expect(mockData.factory).toHaveBeenCalledTimes(1)
-
-        expect(signal.aborted).toBe(false)
-        expect(refetch).not.toBeUndefined()
-        act(() => {
-            refetch()
-        })
-
-        expect(signal.aborted).toBe(true)
-        await waitForElement(() => getByText(/data: /i))
-
-        expect(renderFunction).toHaveBeenCalledTimes(2)
-        expect(mockData.factory).toHaveBeenCalledTimes(2)
     })
 })

--- a/services/data/src/__tests__/mutations.test.tsx
+++ b/services/data/src/__tests__/mutations.test.tsx
@@ -1,4 +1,4 @@
-import { render, act, waitForElement } from '@testing-library/react'
+import { render, act, waitFor } from '@testing-library/react'
 import React from 'react'
 import { Mutation, FetchType, ResolvedResourceQuery, JsonMap } from '../engine'
 import { CustomDataProvider, DataMutation } from '../react'
@@ -71,7 +71,7 @@ describe('Test mutations', () => {
         ])
         expect(mockBackend.target).toHaveBeenCalledTimes(1)
 
-        await waitForElement(() => getByText(/data: /i))
+        await waitFor(() => getByText(/data: /i))
         expect(renderFunction).toHaveBeenCalledTimes(3)
         expect(renderFunction).toHaveBeenLastCalledWith([
             doMutation,

--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -100,7 +100,7 @@ describe('useDataQuery', () => {
     })
 
     describe('Data', () => {
-        it('Should return the data on success', async () => {
+        it('Should return the data for a single resource query on success', async () => {
             const query = { x: { resource: 'answer' } }
             const mockData = { answer: 42 }
             const wrapper = createWrapper(mockData)
@@ -122,16 +122,74 @@ describe('useDataQuery', () => {
                 })
             })
         })
+
+        it('Should return the data for a multiple resource query on success', async () => {
+            const query = {
+                x: { resource: 'answer' },
+                y: { resource: 'opposite' },
+            }
+            const mockData = { answer: 42, opposite: 24 }
+            const wrapper = createWrapper(mockData)
+
+            const { result, waitFor } = renderHook(() => useDataQuery(query), {
+                wrapper,
+            })
+
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitFor(() => {
+                expect(result.current).toMatchObject({
+                    loading: false,
+                    called: true,
+                    data: { x: 42, y: 24 },
+                })
+            })
+        })
     })
 
     describe('Errors', () => {
-        it('Should return any errors it encounters', async () => {
+        it('Should return errors it encounters for a single resource query', async () => {
             const expectedError = new Error('Something went wrong')
             const query = { x: { resource: 'answer' } }
             const mockData = {
                 answer: () => {
                     throw expectedError
                 },
+            }
+            const wrapper = createWrapper(mockData)
+
+            const { result, waitFor } = renderHook(() => useDataQuery(query), {
+                wrapper,
+            })
+
+            expect(result.current).toMatchObject({
+                loading: true,
+                called: true,
+            })
+
+            await waitFor(() => {
+                expect(result.current).toMatchObject({
+                    loading: false,
+                    called: true,
+                    error: expectedError,
+                })
+            })
+        })
+
+        it('Should return errors it encounters for multiple resource queries', async () => {
+            const expectedError = new Error('Something went wrong')
+            const query = {
+                x: { resource: 'answer' },
+                y: { resource: 'opposite' },
+            }
+            const mockData = {
+                answer: () => {
+                    throw expectedError
+                },
+                opposite: 24,
             }
             const wrapper = createWrapper(mockData)
 

--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -5,11 +5,28 @@ import { cache, SWRConfig } from 'swr'
 import { CustomDataProvider } from '../components/CustomDataProvider'
 import { useDataQuery } from './useDataQuery'
 
+// eslint-disable-next-line react/display-name
+const createWrapper = mockData => ({ children }: { children?: ReactNode }) => {
+    return (
+        <SWRConfig value={{ dedupingInterval: 0 }}>
+            <CustomDataProvider data={mockData}>{children}</CustomDataProvider>
+        </SWRConfig>
+    )
+}
+
 describe('useDataQuery', () => {
     const originalError = console.error
 
+    beforeAll(() => {
+        // TODO: suppresses the act warning, we should address this
+        console.error = jest.fn()
+    })
+
     afterEach(async () => {
         await waitFor(() => cache.clear())
+    })
+
+    afterAll(() => {
         console.error = originalError
     })
 
@@ -17,18 +34,7 @@ describe('useDataQuery', () => {
         it('Should set initial loading state to true if not lazy', async () => {
             const query = { x: { resource: 'answer' } }
             const mockData = { answer: 42 }
-            const wrapper = ({ children }: { children?: ReactNode }) => {
-                return (
-                    <SWRConfig value={{ dedupingInterval: 0 }}>
-                        <CustomDataProvider data={mockData}>
-                            {children}
-                        </CustomDataProvider>
-                    </SWRConfig>
-                )
-            }
-
-            // TODO: suppresses the act warning, we should address this
-            console.error = jest.fn()
+            const wrapper = createWrapper(mockData)
 
             const { result } = renderHook(
                 () => useDataQuery(query, { lazy: false }),
@@ -42,22 +48,62 @@ describe('useDataQuery', () => {
         })
     })
 
+    describe('onComplete', () => {
+        it('Should call onComplete with the data after a successful fetch', async () => {
+            const query = { x: { resource: 'answer' } }
+            const mockData = { answer: 42 }
+            const wrapper = createWrapper(mockData)
+            const onComplete = jest.fn()
+            const onError = jest.fn()
+
+            const { result } = renderHook(
+                () => useDataQuery(query, { lazy: false, onComplete, onError }),
+                { wrapper }
+            )
+
+            await waitFor(() => {
+                expect(result.current).toMatchObject({
+                    data: { x: 42 },
+                })
+                expect(onComplete).toHaveBeenCalledWith({ x: 42 })
+                expect(onError).not.toHaveBeenCalled()
+            })
+        })
+    })
+
+    describe('onError', () => {
+        it('Should call onError with the error after an error', async () => {
+            const expectedError = new Error('Something went wrong')
+            const query = { x: { resource: 'answer' } }
+            const mockData = {
+                answer: () => {
+                    throw expectedError
+                },
+            }
+            const wrapper = createWrapper(mockData)
+            const onComplete = jest.fn()
+            const onError = jest.fn()
+
+            const { result, waitFor } = renderHook(
+                () => useDataQuery(query, { onError, onComplete }),
+                { wrapper }
+            )
+
+            await waitFor(() => {
+                expect(result.current).toMatchObject({
+                    error: expectedError,
+                })
+                expect(onError).toHaveBeenCalledWith(expectedError)
+                expect(onComplete).not.toHaveBeenCalled()
+            })
+        })
+    })
+
     describe('Data', () => {
         it('Should return the data on success', async () => {
             const query = { x: { resource: 'answer' } }
             const mockData = { answer: 42 }
-            const wrapper = ({ children }: { children?: ReactNode }) => {
-                return (
-                    <SWRConfig value={{ dedupingInterval: 0 }}>
-                        <CustomDataProvider data={mockData}>
-                            {children}
-                        </CustomDataProvider>
-                    </SWRConfig>
-                )
-            }
-
-            // TODO: suppresses the act warning, we should address this
-            console.error = jest.fn()
+            const wrapper = createWrapper(mockData)
 
             const { result, waitFor } = renderHook(() => useDataQuery(query), {
                 wrapper,
@@ -87,18 +133,7 @@ describe('useDataQuery', () => {
                     throw expectedError
                 },
             }
-            const wrapper = ({ children }: { children?: ReactNode }) => {
-                return (
-                    <SWRConfig value={{ dedupingInterval: 0 }}>
-                        <CustomDataProvider data={mockData}>
-                            {children}
-                        </CustomDataProvider>
-                    </SWRConfig>
-                )
-            }
-
-            // TODO: suppresses the act warning, we should address this
-            console.error = jest.fn()
+            const wrapper = createWrapper(mockData)
 
             const { result, waitFor } = renderHook(() => useDataQuery(query), {
                 wrapper,
@@ -123,18 +158,7 @@ describe('useDataQuery', () => {
         it('Should not fetch until refetch has been called if lazy', async () => {
             const query = { x: { resource: 'answer' } }
             const mockData = { answer: 42 }
-            const wrapper = ({ children }: { children?: ReactNode }) => {
-                return (
-                    <SWRConfig value={{ dedupingInterval: 0 }}>
-                        <CustomDataProvider data={mockData}>
-                            {children}
-                        </CustomDataProvider>
-                    </SWRConfig>
-                )
-            }
-
-            // TODO: suppresses the act warning, we should address this
-            console.error = jest.fn()
+            const wrapper = createWrapper(mockData)
 
             const { result, waitFor } = renderHook(
                 () => useDataQuery(query, { lazy: true }),

--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -162,13 +162,4 @@ describe('useDataQuery', () => {
             })
         })
     })
-
-    /**
-     * TODO
-     * onComplete, onError callbacks
-     * variables (initial)
-     * engine
-     * multiple queries
-     * refetch (for lazy and non-lazy)
-     */
 })

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -1,32 +1,59 @@
-import { useCallback } from 'react'
-import { Query, QueryOptions } from '../../engine'
+import { useState } from 'react'
+import useSWR from 'swr'
+import { Query, QueryOptions, QueryVariables } from '../../engine'
 import { QueryRenderInput } from '../../types'
 import { useDataEngine } from './useDataEngine'
-import { useQueryExecutor } from './useQueryExecutor'
 import { useStaticInput } from './useStaticInput'
 
-const empty = {}
 export const useDataQuery = (
     query: Query,
-    { onComplete, onError, variables = empty, lazy = false }: QueryOptions = {}
+    {
+        onComplete,
+        onError,
+        variables: initialVariables = {},
+        lazy = false,
+    }: QueryOptions = {}
 ): QueryRenderInput => {
-    const engine = useDataEngine()
-    const [theQuery] = useStaticInput<Query>(query, {
+    const [variables, setVariables] = useState(initialVariables)
+    const [enabled, setEnabled] = useState(!lazy)
+
+    // Ensure the query is static
+    const [staticQuery] = useStaticInput<Query>(query, {
         warn: true,
         name: 'query',
     })
-    const execute = useCallback(options => engine.query(theQuery, options), [
-        engine,
-        theQuery,
-    ])
-    const { refetch, called, loading, error, data } = useQueryExecutor({
-        execute,
-        variables,
-        singular: true,
-        immediate: !lazy,
-        onComplete,
-        onError,
-    })
 
-    return { engine, refetch, called, loading, error, data }
+    // TODO: Used as the cache key, this should be deterministically serialized
+    const queryKey = JSON.stringify([staticQuery, variables])
+
+    // The queryfn must return a promise that will either resolve to data or throw an error
+    const engine = useDataEngine()
+    const queryFn = () =>
+        engine.query(staticQuery, { onComplete, onError, variables })
+
+    const shouldFetch = () => (enabled ? queryKey : null)
+    const { error, data } = useSWR(shouldFetch, queryFn)
+
+    // Map our API to swr's API
+    const done = data || error
+    const loading = enabled && !done
+    const called = enabled
+
+    // Callback that allows updating the variables and enabling a lazy query
+    const refetch = (newVariables: QueryVariables) => {
+        if (newVariables) {
+            setVariables({
+                ...variables,
+                ...newVariables,
+            })
+        }
+
+        if (!enabled) {
+            setEnabled(true)
+        }
+    }
+
+    // eslint-disable-next-line
+    // @ts-ignore: refetch does not return a promise currently
+    return { engine, called, loading, error, data, refetch }
 }

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -23,15 +23,12 @@ export const useDataQuery = (
         name: 'query',
     })
 
-    // TODO: Used as the cache key, this should be deterministically serialized
-    const queryKey = JSON.stringify([staticQuery, variables])
-
     // The queryfn must return a promise that will either resolve to data or throw an error
     const engine = useDataEngine()
     const queryFn = () =>
         engine.query(staticQuery, { onComplete, onError, variables })
 
-    const shouldFetch = () => (enabled ? queryKey : null)
+    const shouldFetch = () => (enabled ? [staticQuery, variables] : null)
     const { error, data } = useSWR(shouldFetch, queryFn)
 
     // Map our API to swr's API

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -40,7 +40,9 @@ export const useDataQuery = (
     const called = enabled
 
     // Callback that allows updating the variables and enabling a lazy query
-    const refetch = (newVariables: QueryVariables) => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    const refetch = newVariables => {
         if (newVariables) {
             setVariables({
                 ...variables,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,6 +1132,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.3":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
+  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1909,16 +1916,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^25.5.0":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
-  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
-
 "@jest/types@^26.6.0", "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
@@ -2003,11 +2000,6 @@
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
-
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
-  integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -2160,18 +2152,19 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
-"@testing-library/dom@^6.15.0":
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.16.0.tgz#04ada27ed74ad4c0f0d984a1245bb29b1fd90ba9"
-  integrity sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==
+"@testing-library/dom@^7.22.3":
+  version "7.30.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.4.tgz#c6a4a91557e92035fd565246bbbfb8107aa4634d"
+  integrity sha512-GObDVMaI4ARrZEXaRy4moolNAxWPKvEYNV/fa6Uc2eAzR/t4otS6A7EhrntPBIQLeehL9DbVhscvvv7gd6hWqA==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    "@types/testing-library__dom" "^6.12.1"
-    aria-query "^4.0.2"
-    dom-accessibility-api "^0.3.0"
-    pretty-format "^25.1.0"
-    wait-for-expect "^3.0.2"
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
 
 "@testing-library/jest-dom@^5.0.2":
   version "5.11.9"
@@ -2195,14 +2188,13 @@
     "@babel/runtime" "^7.12.5"
     "@types/testing-library__react-hooks" "^3.4.0"
 
-"@testing-library/react@^9.4.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.5.0.tgz#71531655a7890b61e77a1b39452fbedf0472ca5e"
-  integrity sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==
+"@testing-library/react@^10.0.0":
+  version "10.4.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.4.9.tgz#9faa29c6a1a217bf8bbb96a28bd29d7a847ca150"
+  integrity sha512-pHZKkqUy0tmiD81afs8xfiuseXfU/N7rAX3iKjeZYje86t9VaB0LrxYVa+OOsvkrveX5jCK3IjajVn2MbePvqA==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@testing-library/dom" "^6.15.0"
-    "@types/testing-library__react" "^9.1.2"
+    "@babel/runtime" "^7.10.3"
+    "@testing-library/dom" "^7.22.3"
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -2382,13 +2374,6 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@types/react-dom@*":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.1.tgz#d92d77d020bfb083e07cc8e0ac9f933599a4d56a"
-  integrity sha512-yIVyopxQb8IDZ7SOHeTovurFq+fXiPICa+GV3gp0Xedsl+MwQlMLKmvrnEjFbQxjliH5YVAEWFh975eVNmKj7Q==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-dom@^16.9.5":
   version "16.9.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.11.tgz#752e223a1592a2c10f2668b215a0e0667f4faab1"
@@ -2446,19 +2431,12 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
 
-"@types/testing-library__dom@*", "@types/testing-library__dom@^7.5.0":
+"@types/testing-library__dom@^7.5.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-7.5.0.tgz#e0a00dd766983b1d6e9d10d33e708005ce6ad13e"
   integrity sha512-mj1aH4cj3XUpMEgVpognma5kHVtbm6U6cHZmEFzCRiXPvKkuHrFr3+yXdGLXvfFRBaQIVshPGHI+hGTOJlhS/g==
   dependencies:
     "@testing-library/dom" "*"
-
-"@types/testing-library__dom@^6.12.1":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
-  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
-  dependencies:
-    pretty-format "^24.3.0"
 
 "@types/testing-library__jest-dom@^5.9.1":
   version "5.9.5"
@@ -2473,15 +2451,6 @@
   integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
   dependencies:
     "@types/react-test-renderer" "*"
-
-"@types/testing-library__react@^9.1.2":
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.3.tgz#35eca61cc6ea923543796f16034882a1603d7302"
-  integrity sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==
-  dependencies:
-    "@types/react-dom" "*"
-    "@types/testing-library__dom" "*"
-    pretty-format "^25.1.0"
 
 "@types/uglify-js@*":
   version "3.12.0"
@@ -3137,7 +3106,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^4.0.2, aria-query@^4.2.2:
+aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
   integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
@@ -5378,6 +5347,11 @@ depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -5512,11 +5486,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-dom-accessibility-api@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
-  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
 
 dom-accessibility-api@^0.5.4:
   version "0.5.4"
@@ -11774,7 +11743,7 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^24.3.0, pretty-format@^24.9.0:
+pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -11783,16 +11752,6 @@ pretty-format@^24.3.0, pretty-format@^24.9.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
-
-pretty-format@^25.1.0:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
-  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
-  dependencies:
-    "@jest/types" "^25.5.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
 
 pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
   version "26.6.2"
@@ -12104,7 +12063,7 @@ react-final-form@^6.5.1:
   dependencies:
     "@babel/runtime" "^7.12.1"
 
-react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -13846,6 +13805,13 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+swr@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.5.5.tgz#c72c1615765f33570a16bbb13699e3ac87eaaa3a"
+  integrity sha512-u4mUorK9Ipt+6LEITvWRWiRWAQjAysI6cHxbMmMV1dIdDzxMnswWo1CyGoyBHXX91CchxcuoqgFZ/ycx+YfhCA==
+  dependencies:
+    dequal "2.0.2"
+
 symbol-tree@^3.2.2, symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -14784,11 +14750,6 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
-
-wait-for-expect@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
-  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
 walk-back@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Implements client side caching with useswr (https://swr.vercel.app). See https://jira.dhis2.org/browse/LIBS-166 for the related epic.

Notes:

- Some types need to be fixed, ignored some of them for the moment
- Currently not cancelling requests. useSWR doesn't have an explicit API for this yet: https://github.com/vercel/swr/issues/129, though there are possibilities apparently
- We're not using the arguments passed by swr to the queryFn (engine.query in our case) at the moment. Though it should be possible to use the arguments that swr passes us.
- Refetch does not return a promise currently, so this is incompatible with how our refetch used to work. We'll need to see if we want to either drop this behaviour, or implement it with useSWR with the new refetch.
- onComplete and onError will fire for each request. Even when swr is serving cached data. Could be problematic. It might mess with app logic when swr returns (stale) data and an error callback fires.
- SWR also supplies onSuccess and onError hooks to pass a callback to. We could use those as well.
- The cache key for a group of queries could change if a single query of the group of queries changes, even though it should only affect the cache key of the changed query. This means that currently caching isn't as efficient with multiple queries for one hook. There doesn't seem to be anything native to swr that allows multiple queries easily like react-query's useQueries.
- Unlike react-query, useSWR uses referential equality checks to check whether the cache key has changed.

Tests:

- [x] onComplete, onError callbacks
- [x] variables (initial)
- [x] multiple queries
- [x] refetch (for lazy and non-lazy)

API docs:

- https://swr.vercel.app/docs/options

Follow-up (unrelated to swr):

- [x] Remove waitForElement
- [ ] Address act warnings (everything in renderHook should already be wrapped in act)
