### PR TITLE
docs: add to alerts docs

### DIFF
--- a/docs/hooks/useAlert.md
+++ b/docs/hooks/useAlert.md
@@ -4,10 +4,10 @@
 
 ## Hook arguments
 
-| Name      | Type                   | Description                                                                                                                                            |
-| --------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `message` | `string` or `Function` | The message to display                                                                                                                                 |
-| `options` | `object` or `Function` | A configuration object that matches [the props  of the `AlertBar`](https://ui.dhis2.nu/demo/?path=/docs/feedback-alerts-alert-bar--default) in `@dhis2/ui` (alternate: [minimal view](https://ui.dhis2.nu/#/api?id=coresrcalertbaralertbarproptypes-object) of the props) |
+| Name      | Type                   | Description                                                                                                                                                                                                                                                              |
+| --------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `message` | `string` or `Function` | The message to display                                                                                                                                                                                                                                                   |
+| `options` | `object` or `Function` | A configuration object that matches [the props of the `AlertBar`](https://ui.dhis2.nu/demo/?path=/docs/feedback-alerts-alert-bar--default) in `@dhis2/ui` (alternate: [minimal view](https://ui.dhis2.nu/#/api?id=coresrcalertbaralertbarproptypes-object) of the props) |
 
 ## Usage of the returned `show` function
 

--- a/docs/hooks/useAlert.md
+++ b/docs/hooks/useAlert.md
@@ -7,7 +7,7 @@
 | Name      | Type                   | Description                                                                                                                                            |
 | --------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `message` | `string` or `Function` | The message to display                                                                                                                                 |
-| `options` | `object` or `Function` | A configuration object that matches [the props](https://ui.dhis2.nu/#/api?id=coresrcalertbaralertbarproptypes-object) of the `AlertBar` in `@dhis2/ui` |
+| `options` | `object` or `Function` | A configuration object that matches [the props  of the `AlertBar`](https://ui.dhis2.nu/demo/?path=/docs/feedback-alerts-alert-bar--default) in `@dhis2/ui` (alternate: [minimal view](https://ui.dhis2.nu/#/api?id=coresrcalertbaralertbarproptypes-object) of the props) |
 
 ## Usage of the returned `show` function
 

--- a/docs/hooks/useAlerts.md
+++ b/docs/hooks/useAlerts.md
@@ -2,6 +2,10 @@
 
 `useAlerts() → Alert[]`
 
+## Usage note
+
+The app-shell wraps the app in an `AlertsProvider` and also includes an `Alerts` component which leverages `useAlerts` to show `AlertBars` in an `AlertStack` (`@dhis2/ui` components). So in a typical DHIS2 app the only thing you need to use from the alerts-service is the `useAlert` hook.
+
 ## Alert
 
 | Prop      | Type       | Description                                                                                                                                            |
@@ -25,7 +29,3 @@ export const Alerts = () => {
     ))
 }
 ```
-
-## Usage note
-
-The app-shell wraps the app in an `AlertsProvider` and also includes an `Alerts` component which leverages `useAlerts` to show `AlertBars` in an `AlertStack` (`@dhis2/ui` components). So in a typical DHIS2 app the only thing you need to use from the alerts-service is the `useAlert` hook.


### PR DESCRIPTION
Two changes intended to make useAlert easier to use for new users/academy participants:

1. Add link to the AlertBar storybook page so users can browse what the different AlertBar props do
2. Move the 'Usage note' in useAlert**s** to the top of the page to point readers in the direction of the plain useAlert hook