### PR TITLE
feat(data-provider): enable context sharing

### DIFF
--- a/services/data/src/react/components/DataProvider.tsx
+++ b/services/data/src/react/components/DataProvider.tsx
@@ -24,7 +24,7 @@ export const DataProvider = (props: ProviderInput) => {
     const context = { engine }
 
     return (
-        <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={queryClient} contextSharing>
             <DataContext.Provider value={context}>
                 {props.children}
             </DataContext.Provider>


### PR DESCRIPTION
This enables [context sharing](https://react-query.tanstack.com/reference/QueryClientProvider) on the QueryClientProvider, which allows react-query to find a provider even if that provider was imported from a different instance of react-query. This is a feature we'll want to use eventually anyway, but it can also help alleviate dependency issues, where the app will crash if multiple copies of react-query are used (and thus no compatible context can be found).