### PR TITLE
feat(use-data-query): set conservative defaults for caching

### DIFF
--- a/services/data/src/react/components/CustomDataProvider.tsx
+++ b/services/data/src/react/components/CustomDataProvider.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import { DataEngine } from '../../engine'
 import { CustomDataLink, CustomData, CustomLinkOptions } from '../../links'
 import { DataContext } from '../context/DataContext'
+import { queryClientOptions as queryClientDefaults } from './DataProvider'
 
 interface CustomProviderInput {
     children: React.ReactNode
@@ -11,23 +12,11 @@ interface CustomProviderInput {
     queryClientOptions?: any
 }
 
-/**
- * Disable automatic retries, which can cause tests to take unnecessarily long
- * see: https://react-query.tanstack.com/reference/useQuery
- */
-const defaultQueryClientOptions = {
-    defaultOptions: {
-        queries: {
-            retry: false,
-        },
-    },
-}
-
 export const CustomDataProvider = ({
     children,
     data,
     options,
-    queryClientOptions = defaultQueryClientOptions,
+    queryClientOptions = queryClientDefaults,
 }: CustomProviderInput) => {
     const link = new CustomDataLink(data, options)
     const engine = new DataEngine(link)

--- a/services/data/src/react/components/DataProvider.tsx
+++ b/services/data/src/react/components/DataProvider.tsx
@@ -11,7 +11,22 @@ export interface ProviderInput {
     children: React.ReactNode
 }
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            // Disable automatic error retries
+            retry: false,
+            // Don't retry on mount if query has errored
+            retryOnMount: false,
+            // Refetch on mount if data is stale
+            refetchOnMount: true,
+            // Don't refetch when the window regains focus
+            refetchOnWindowFocus: false,
+            // Don't refetch after connection issues
+            refetchOnReconnect: false,
+        },
+    },
+})
 
 export const DataProvider = (props: ProviderInput) => {
     const config = {

--- a/services/data/src/react/components/DataProvider.tsx
+++ b/services/data/src/react/components/DataProvider.tsx
@@ -11,13 +11,13 @@ export interface ProviderInput {
     children: React.ReactNode
 }
 
-const queryClient = new QueryClient({
+export const queryClientOptions = {
     defaultOptions: {
         queries: {
             // Disable automatic error retries
             retry: false,
-            // Don't retry on mount if query has errored
-            retryOnMount: false,
+            // Retry on mount if query has errored
+            retryOnMount: true,
             // Refetch on mount if data is stale
             refetchOnMount: true,
             // Don't refetch when the window regains focus
@@ -26,7 +26,9 @@ const queryClient = new QueryClient({
             refetchOnReconnect: false,
         },
     },
-})
+}
+
+const queryClient = new QueryClient(queryClientOptions)
 
 export const DataProvider = (props: ProviderInput) => {
     const config = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,6 +1347,30 @@
   dependencies:
     moment "^2.24.0"
 
+"@dhis2/app-runtime@^2.6.1":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.8.0.tgz#83ca6e96c299686ee72eea3e1825e04aa53cd5d2"
+  integrity sha512-Ru6x9L61fD7ITzVaxFqx88kV5/ypB9xSr8nHgRj4EE/kHl/aVejXuwnSS2OIWh80J3mtD1dpNRN/GJ8o0x0HYg==
+  dependencies:
+    "@dhis2/app-service-alerts" "2.8.0"
+    "@dhis2/app-service-config" "2.8.0"
+    "@dhis2/app-service-data" "2.8.0"
+
+"@dhis2/app-service-alerts@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-2.8.0.tgz#f480043a15b5a2b7d90a6e74931ddd3ebb65aa1c"
+  integrity sha512-hpMqdxCG9w5H2EZyLPQKcKzCdp/Sof68ZGd85lNHo+1c10+1pWhKAjt/p3zoRllHppp17TbEgKoXa1oRx2NeHg==
+
+"@dhis2/app-service-config@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-2.8.0.tgz#4ce7520e28a7700fa11ad7bcba6468a0a58751a4"
+  integrity sha512-SZnoa2EjsgV8a1QfnSk6fqxORV3pRcA+SYyz/H/nkr/VodkdgmO5CiwlZxXW8pG+4i6sbMGjGualam2jHF34wg==
+
+"@dhis2/app-service-data@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-2.8.0.tgz#9cd347127968cb6f3c8a4ab0fc6699ea7058f835"
+  integrity sha512-5doyL4bxRMdMXY4RtWo2O3NVGwSDOSUY3hGPXaF1TeFWAqujlPTx17uDw6wEelN6LaryAnVwId2Ep3FOV8v5MA==
+
 "@dhis2/app-shell@5.7.1":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-5.7.1.tgz#bfabdd828afca53da62f39d5a56aa397b67cd3f1"


### PR DESCRIPTION
I've enabled both `retryOnMount` and `refetchOnMount`. This way react-query will trigger a fetch for newly mounted components with an identical query, which is what we currently do.

I've disabled automatic retries on errors, automatic revalidation on window focus and revalidation on reestablished network connections.

The feature that we cannot disable, but that should also be safe to leave enabled is automatic query deduplication. If a query is already fetching, react-query will not create a new fetch for any queries with an identical queryKey. As soon as the promise has settled react-query will allow new fetches again.