### PR TITLE
fix(use-data-query): make swr opt-in

### DIFF
--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -57,17 +57,15 @@ export const useDataQuery = (
     const queryKey = [staticQuery, variables]
     const queryFn = () => engine.query(staticQuery, { variables })
 
-    const {
-        isIdle,
-        isLoading: loading,
-        error,
-        data,
-        refetch: queryRefetch,
-    } = useQuery(queryKey, queryFn, {
-        enabled,
-        onSuccess,
-        onError,
-    })
+    const { isIdle, isFetching, error, data, refetch: queryRefetch } = useQuery(
+        queryKey,
+        queryFn,
+        {
+            enabled,
+            onSuccess,
+            onError,
+        }
+    )
 
     /**
      * Refetch allows a user to update the variables or just
@@ -107,13 +105,12 @@ export const useDataQuery = (
      * or an error, so this ensures consistency with the other types.
      */
     const ourError = error || undefined
-    // A query is idle if it is lazy and no initial data is available.
-    const ourCalled = !isIdle
 
     return {
         engine,
-        called: ourCalled,
-        loading,
+        // A query is idle if it is lazy and no initial data is available.
+        called: !isIdle,
+        loading: isFetching,
         error: ourError,
         data,
         refetch,


### PR DESCRIPTION
This updates the prop we use to show the user whether content is loading or not. Previously we used react-query's `isLoading` and we've now moved to `isFetching`. The difference is that `isLoading` will only be true when there's no data, and a fetch is in progress. `isFetching` will always be true if a fetch is in progress, so it works the same way `loading` does on app-runtime's `master`.

This means that stale-while-revalidate is now opt-in. If a user wants to opt-in to stale-while-revalidate they can switch from using:

```
if (loading) {
  // Show spinner
}
```

to:

```
if (loading && !called) {
  // Show spinner
}
```

The one thing that seems iffy to me is that we need to manually rerender to get the expected state in the test. I've added a comment and will follow up on that in a separate issue.