### PR TITLE
fix(use-data-query): drop context sharing

### DIFF
--- a/services/data/src/react/components/DataProvider.tsx
+++ b/services/data/src/react/components/DataProvider.tsx
@@ -41,7 +41,7 @@ export const DataProvider = (props: ProviderInput): JSX.Element => {
     const context = { engine }
 
     return (
-        <QueryClientProvider client={queryClient} contextSharing>
+        <QueryClientProvider client={queryClient}>
             <DataContext.Provider value={context}>
                 {props.children}
             </DataContext.Provider>


### PR DESCRIPTION
Removes the contextSharing that was enabled by default on the react-query provider. See: https://github.com/dhis2/app-runtime/pull/916