### PR TITLE
fix(logging): silence react-query logger by default

### DIFF
--- a/services/data/src/__tests__/integration.test.tsx
+++ b/services/data/src/__tests__/integration.test.tsx
@@ -1,22 +1,7 @@
 import { render, waitFor } from '@testing-library/react'
 import React, { ReactNode } from 'react'
-import { setLogger } from 'react-query'
 import { CustomDataProvider, DataQuery } from '../react'
 import { QueryRenderInput } from '../types'
-
-beforeAll(() => {
-    // Prevent the react-query logger from logging to the console
-    setLogger({
-        log: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    })
-})
-
-afterAll(() => {
-    // Restore the original react-query logger
-    setLogger(console)
-})
 
 describe('Testing custom data provider and useQuery hook', () => {
     it('Should render without failing', async () => {

--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -1,22 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks'
 import React from 'react'
-import { setLogger } from 'react-query'
 import { CustomDataProvider } from '../components/CustomDataProvider'
 import { useDataQuery } from './useDataQuery'
-
-beforeAll(() => {
-    // Prevent the react-query logger from logging to the console
-    setLogger({
-        log: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    })
-})
-
-afterAll(() => {
-    // Restore the original react-query logger
-    setLogger(console)
-})
 
 describe('useDataQuery', () => {
     describe('parameters: onComplete', () => {

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -1,10 +1,24 @@
 import { useState, useRef } from 'react'
-import { useQuery } from 'react-query'
+import { useQuery, setLogger } from 'react-query'
 import { Query, QueryOptions } from '../../engine'
 import { FetchError } from '../../engine/types/FetchError'
 import { QueryRenderInput, QueryRefetchFunction } from '../../types'
 import { useDataEngine } from './useDataEngine'
 import { useStaticInput } from './useStaticInput'
+
+const noop = () => {
+    /**
+     * Used to silence the default react-query logger. Eventually we
+     * could expose the setLogger functionality and remove the call
+     * to setLogger here.
+     */
+}
+
+setLogger({
+    log: noop,
+    warn: noop,
+    error: noop,
+})
 
 export const useDataQuery = (
     query: Query,


### PR DESCRIPTION
Since we don't want to expose any new API for the upcoming changes, users don't really have a way to silence/configure the react-query logger. So for now I'm silencing it by default as otherwise test output will be polluted by the logger. Eventually we could expose API that allows users to control this.

https://react-query.tanstack.com/reference/setLogger