### PR TITLE
fix: allow useCachableSection hook to be used in child of CacheableSection

### DIFF
--- a/services/offline/src/lib/cacheable-section.tsx
+++ b/services/offline/src/lib/cacheable-section.tsx
@@ -55,9 +55,15 @@ export function useCacheableSection(id: string): CacheableSectionControls {
 
     useEffect(() => {
         // On mount, add recording state for this ID to context
-        setRecordingState(recordingStates.default)
+        if (!recordingState) {
+            setRecordingState(recordingStates.default)
+        }
         // On unnmount, remove recording state
-        return () => removeRecordingState()
+        return () => {
+            if (recordingState === recordingStates.default) {
+                removeRecordingState()
+            }
+        }
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     function startRecording({

--- a/services/offline/src/lib/cacheable-section.tsx
+++ b/services/offline/src/lib/cacheable-section.tsx
@@ -58,11 +58,12 @@ export function useCacheableSection(id: string): CacheableSectionControls {
         if (!recordingState) {
             setRecordingState(recordingStates.default)
         }
-        // On unnmount, remove recording state if possible
+        // On unnmount, remove recording state if not recording
         return () => {
             if (
-                recordingState === recordingStates.default ||
-                recordingState === recordingStates.error
+                recordingState &&
+                recordingState !== recordingStates.recording &&
+                recordingState !== recordingStates.pending
             ) {
                 removeRecordingState()
             }

--- a/services/offline/src/lib/cacheable-section.tsx
+++ b/services/offline/src/lib/cacheable-section.tsx
@@ -54,13 +54,16 @@ export function useCacheableSection(id: string): CacheableSectionControls {
     } = useRecordingState(id)
 
     useEffect(() => {
-        // On mount, add recording state for this ID to context
+        // On mount, add recording state for this ID to context if needed
         if (!recordingState) {
             setRecordingState(recordingStates.default)
         }
-        // On unnmount, remove recording state
+        // On unnmount, remove recording state if possible
         return () => {
-            if (recordingState === recordingStates.default) {
+            if (
+                recordingState === recordingStates.default ||
+                recordingState === recordingStates.error
+            ) {
                 removeRecordingState()
             }
         }


### PR DESCRIPTION
Because `useCacheableSection` sets its section's recording state to `'default'` on mount, it doesn't work to use it inside of the the `<CacheableSection>` component it's controlling: when the section rerenders to record, the recording state is faultily set back to `'default'` instead of `'recording'` when the hook rerenders.

This is a hotfix to fix that behavior: recording state in context isn't set if one exists already, and won't be cleared from context on unmount unless the recording state is `'default'`.  

There is a tiny side effect that in unusual cases where recording states of sections that a user is not viewing are still stored in context after switching to a different section while the recording state is not `'default'`, but that should be both harmless and extremely unusual given the loading mask. In the future this might improved by refactoring how recording state is coordinated between the service worker and the React context