### PR TITLE
docs: use consistent headings and formatting

### DIFF
--- a/docs/components/DataMutation.md
+++ b/docs/components/DataMutation.md
@@ -19,13 +19,13 @@ return (
 
 ## Input Props
 
-|      Name      |              Type               |   Required   | Description                                                                                                                   |
-| :------------: | :-----------------------------: | :----------: | ----------------------------------------------------------------------------------------------------------------------------- |
-|  **mutation**  | [_Mutation_](types/Mutation.md) | **required** | The Mutation definition describing the requested operation                                                                    |
-| **variables**  |            _Object_             |              | Variables to be passed to the dynamic portions of the mutation                                                                |
-| **onComplete** |           _Function_            |              | Callback function to be called on successfull completion of the mutation. Called with the response data as the only argument. |
-|  **onError**   |           _Function_            |              | Callback function to be called on failure of the mutation. Called with the error instance as the only argument.               |
-|    **lazy**    |            _boolean_            |              | If false, run the mutation immediately after the component mounts.<br/>_**Default**: `true`_                                  |
+| Name           | Type                            | Required     | Description                                                                                                                   |
+| -------------- | ------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| **mutation**   | [_Mutation_](types/Mutation.md) | **required** | The Mutation definition describing the requested operation                                                                    |
+| **variables**  | _object_                        |              | Variables to be passed to the dynamic portions of the mutation                                                                |
+| **onComplete** | _function_                      |              | Callback function to be called on successfull completion of the mutation. Called with the response data as the only argument. |
+| **onError**    | _function_                      |              | Callback function to be called on failure of the mutation. Called with the error instance as the only argument.               |
+| **lazy**       | _boolean_                       |              | If false, run the mutation immediately after the component mounts.<br/>_**Default**: `true`_                                  |
 
 ## Render Function Props
 
@@ -34,13 +34,13 @@ The render function is called whenever the state of the mutation changes. It is 
 1. `mutate` - a function which can be called to trigger the mutation (for instance in an onClick callback)
 2. `state` - an object containing the following properties:
 
-|    Name     |                  Type                   | Description                                                                                                                                                                            |
-| :---------: | :-------------------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **called**  |                _boolean_                | **true** if the mutation has been triggered through a call to the `mutate` function or on component mount with `lazy: false`                                                           |
-| **loading** |                _boolean_                | **true** if the data is not yet available and no error has yet been encountered                                                                                                        |
-|  **error**  |     _Error_<br/>or<br/>_undefined_      | **undefined** if no error has occurred, otherwise the Error which was thrown                                                                                                           |
-|  **data**   | _MutationResult_<br/>or<br/>_undefined_ | **undefined** if the data is loading or an error has occurred, otherwise a map from the name of each **QueryDefinition** defined in the **Query** to the resulting data for that query |
-| **engine**  |  [_Data Engine_](advanced/DataEngine)   | A reference to the DataEngine instance                                                                                                                                                 |
+| Name        | Type                                    | Description                                                                                                                                                                            |
+| ----------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **called**  | _boolean_                               | **true** if the mutation has been triggered through a call to the `mutate` function or on component mount with `lazy: false`                                                           |
+| **loading** | _boolean_                               | **true** if the data is not yet available and no error has yet been encountered                                                                                                        |
+| **error**   | _Error_<br/>or<br/>_undefined_          | **undefined** if no error has occurred, otherwise the Error which was thrown                                                                                                           |
+| **data**    | _MutationResult_<br/>or<br/>_undefined_ | **undefined** if the data is loading or an error has occurred, otherwise a map from the name of each **QueryDefinition** defined in the **Query** to the resulting data for that query |
+| **engine**  | [_DataEngine_](advanced/DataEngine)     | A reference to the DataEngine instance                                                                                                                                                 |
 
 ## Example
 

--- a/docs/components/DataQuery.md
+++ b/docs/components/DataQuery.md
@@ -19,24 +19,24 @@ return (
 
 ## Input Props
 
-|      Name      |           Type            |   Required   | Description                                                                                                                |
-| :------------: | :-----------------------: | :----------: | -------------------------------------------------------------------------------------------------------------------------- |
-|   **query**    | [_Query_](types/Query.md) | **required** | The Query definition describing the requested data                                                                         |
-| **variables**  |         _Object_          |              | Variables to be passed to the dynamic portions of the query                                                                |
-| **onComplete** |        _Function_         |              | Callback function to be called on successfull completion of the query. Called with the response data as the only argument. |
-|  **onError**   |        _Function_         |              | Callback function to be called on failure of the query. Called with the error instance as the only argument.               |
-|    **lazy**    |         _boolean_         |              | If true, wait until `refetch` is called before fetching data.<br/>_**Default**: `false`_                                   |
+| Name           | Type                      | Required     | Description                                                                                                                |
+| -------------- | ------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| **query**      | [_Query_](types/Query.md) | **required** | The Query definition describing the requested data                                                                         |
+| **variables**  | _object_                  |              | Variables to be passed to the dynamic portions of the query                                                                |
+| **onComplete** | _function_                |              | Callback function to be called on successfull completion of the query. Called with the response data as the only argument. |
+| **onError**    | _function_                |              | Callback function to be called on failure of the query. Called with the error instance as the only argument.               |
+| **lazy**       | _boolean_                 |              | If true, wait until `refetch` is called before fetching data.<br/>_**Default**: `false`_                                   |
 
 ## Render Function Props
 
-|    Name     |                 Type                 | Description                                                                                                                                                                            |
-| :---------: | :----------------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **called**  |              _boolean_               | **true** if the data request has been initiated with either `lazy: false` or `refetch()` at least once                                                                                 |
-| **loading** |              _boolean_               | **true** if the data is not yet available and no error has yet been encountered                                                                                                        |
-|  **error**  |    _Error_<br/>or<br/>_undefined_    | **undefined** if no error has occurred, otherwise the Error which was thrown                                                                                                           |
-|  **data**   | _QueryResult_<br/>or<br/>_undefined_ | **undefined** if the data is loading or an error has occurred, otherwise a map from the name of each **QueryDefinition** defined in the **Query** to the resulting data for that query |
-| **refetch** |              _Function_              | This function can be called to refetch the data. Any in-flight HTTP requests will automatically be aborted.                                                                            |
-| **engine**  | [_Data Engine_](advanced/DataEngine) | A reference to the DataEngine instance                                                                                                                                                 |
+| Name        | Type                                 | Description                                                                                                                                                                            |
+| ----------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **called**  | _boolean_                            | **true** if the data request has been initiated with either `lazy: false` or `refetch()` at least once                                                                                 |
+| **loading** | _boolean_                            | **true** if the data is not yet available and no error has yet been encountered                                                                                                        |
+| **error**   | _Error_<br/>or<br/>_undefined_       | **undefined** if no error has occurred, otherwise the Error which was thrown                                                                                                           |
+| **data**    | _QueryResult_<br/>or<br/>_undefined_ | **undefined** if the data is loading or an error has occurred, otherwise a map from the name of each **QueryDefinition** defined in the **Query** to the resulting data for that query |
+| **refetch** | _function_                           | This function can be called to refetch the data. Any in-flight HTTP requests will automatically be aborted.                                                                            |
+| **engine**  | [_DataEngine_](advanced/DataEngine)  | A reference to the DataEngine instance                                                                                                                                                 |
 
 ## Example
 

--- a/docs/hooks/useAlert.md
+++ b/docs/hooks/useAlert.md
@@ -1,13 +1,26 @@
-# `useAlert`
+# useAlert Hook
 
-`useAlert(message, options?) → { show }`
+## Basic Usage:
 
-## Hook arguments
+```js
+import { useAlert } from '@dhis2/app-runtime'
 
-| Name      | Type                   | Description                                                                                                                                                                                                                                                              |
-| --------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `message` | `string` or `Function` | The message to display                                                                                                                                                                                                                                                   |
-| `options` | `object` or `Function` | A configuration object that matches [the props of the `AlertBar`](https://ui.dhis2.nu/demo/?path=/docs/feedback-alerts-alert-bar--default) in `@dhis2/ui` (alternate: [minimal view](https://ui.dhis2.nu/#/api?id=coresrcalertbaralertbarproptypes-object) of the props) |
+// Within a functional component body
+const { show } = useAlert(message, options)
+```
+
+## Input
+
+| Name    | Type                   | Required     | Description                                                                                                             |
+| ------- | ---------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| message | _string_ or _function_ | **required** | The message to display                                                                                                  |
+| options | _object_ or _function_ |              | A configuration object that matches [the props of the `AlertBar`](https://ui.dhis2.nu/#/api?id=alertbar) in `@dhis2/ui` |
+
+## Output
+
+| Name | Type       | Description                                            |
+| ---- | ---------- | ------------------------------------------------------ |
+| show | _function_ | A new alert is shown each time this function is called |
 
 ## Usage of the returned `show` function
 
@@ -39,6 +52,36 @@ show({ username: 'hendrik', isCurrentUser: true })
 ```
 
 The two approaches can also be combined, i.e. having a static `message` and dynamic `options` or vice versa.
+
+## Example
+
+```jsx
+import React from 'react'
+import { useAlert, useDataMutation } from '@dhis2/app-runtime'
+
+const mutation = {
+    resource: 'mutation',
+    type: 'create',
+}
+
+const MyComponent = () => {
+    const successAlert = useAlert('Mutation succeeded', { success: true })
+    const errorAlert = useAlert(({ error }) => `Mutation error: ${error}`, {
+        critical: true,
+    })
+
+    const [mutate] = useDataMutation(mutation, {
+        onComplete() {
+            successAlert.show()
+        },
+        onError(error) {
+            errorAlert.show({ error: error.message })
+        },
+    })
+
+    return <Button onClick={mutate}>Trigger mutation</Button>
+}
+```
 
 ## Usage note
 

--- a/docs/hooks/useAlerts.md
+++ b/docs/hooks/useAlerts.md
@@ -1,23 +1,44 @@
-# `useAlerts`
+# useAlerts Hook
 
 `useAlerts() → Alert[]`
 
+> In a typical DHIS2 app **the only thing you need to use from the alerts-service is [the `useAlert` hook](hooks/useAlert)**
+
 ## Usage note
 
-The app-shell wraps the app in an `AlertsProvider` and also includes an `Alerts` component which leverages `useAlerts` to show `AlertBars` in an `AlertStack` (`@dhis2/ui` components). So in a typical DHIS2 app the only thing you need to use from the alerts-service is the `useAlert` hook.
+The app-shell wraps the app in an `AlertsProvider` and also includes an `Alerts` component which leverages `useAlerts` to show `AlertBars` in an `AlertStack` (`@dhis2/ui` components). So in a typical DHIS2 app **the only thing you need to use from the alerts-service is [the `useAlert` hook](hooks/useAlert)**.
+
+## Basic Usage:
+
+```js
+import { useAlerts } from '@dhis2/app-runtime'
+
+// Within a functional component body
+const alerts = useAlerts()
+```
+
+## Input
+
+_None_
+
+## Output
+
+| Name       | Type                                           |
+| ---------- | ---------------------------------------------- |
+| **alerts** | _array_ of [_Alert_](hooks/useAlerts?id=alert) |
 
 ## Alert
 
-| Prop      | Type       | Description                                                                                                                                            |
-| --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `message` | `string`   | The alert message to display                                                                                                                           |
-| `id`      | `number`   | Can be used as `key` when mapping over `alerts`                                                                                                        |
-| `remove`  | `function` | Call this to remove the `alert`                                                                                                                        |
-| `options` | `object`   | A configuration object that matches [the props](https://ui.dhis2.nu/#/api?id=coresrcalertbaralertbarproptypes-object) of the `AlertBar` in `@dhis2/ui` |
+| Prop        | Type       | Description                                                                                                             |
+| ----------- | ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **message** | `string`   | The alert message to display                                                                                            |
+| **id**      | `number`   | Can be used as `key` when mapping over `alerts`                                                                         |
+| **remove**  | `function` | Call this to remove the `alert`                                                                                         |
+| **options** | `object`   | A configuration object that matches [the props of the `AlertBar`](https://ui.dhis2.nu/#/api?id=alertbar) in `@dhis2/ui` |
 
 ## Example
 
-```js
+```jsx
 export const Alerts = () => {
     const alerts = useAlerts()
 

--- a/docs/hooks/useConfig.md
+++ b/docs/hooks/useConfig.md
@@ -27,14 +27,15 @@ import { useConfig } from '@dhis2/app-runtime'
 
 export const MyComponent = () => {
     const { baseUrl, apiVersion } = useConfig()
-    return
-    ;<div>
-        <span>
-            <strong>Base URL</strong> : {baseUrl}
-        </span>
-        <span>
-            <strong>API Version</strong> : {apiVersion}
-        </span>
-    </div>
+    return (
+        <div>
+            <span>
+                <strong>Base URL</strong> : {baseUrl}
+            </span>
+            <span>
+                <strong>API Version</strong> : {apiVersion}
+            </span>
+        </div>
+    )
 }
 ```

--- a/docs/hooks/useDataEngine.md
+++ b/docs/hooks/useDataEngine.md
@@ -1,4 +1,4 @@
-# useDataEngine hook
+# useDataEngine Hook
 
 Get access to the [Data Engine](advanced/DataEngine) instance for non-React contexts.
 

--- a/docs/hooks/useDataMutation.md
+++ b/docs/hooks/useDataMutation.md
@@ -16,25 +16,25 @@ const [mutate, { called, loading, error, data }] = useDataMutation(
 
 ## Input
 
-|          Name          |              Type               |   Required   | Description                                                                                                                   |
-| :--------------------: | :-----------------------------: | :----------: | ----------------------------------------------------------------------------------------------------------------------------- |
-|      **mutation**      | [_Mutation_](types/Mutation.md) | **required** | The Mutation definition describing the requested action                                                                       |
-|      **options**       |            _Object_             |              | An optional set of query options                                                                                              |
-| **options.variables**  |            _Object_             |              | Variables to be passed to the dynamic portions of the mutation                                                                |
-| **options.onComplete** |           _Function_            |              | Callback function to be called on successfull completion of the mutation. Called with the response data as the only argument. |
-|  **options.onError**   |           _Function_            |              | Callback function to be called on failure of the mutation. Called with the error instance as the only argument.               |
-|    **options.lazy**    |            _boolean_            |              | If false, run the mutation immediately after the component mounts.<br/>_**Default**: `true`_                                  |
+| Name                   | Type                            | Required     | Description                                                                                                                   |
+| ---------------------- | ------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| **mutation**           | [_Mutation_](types/Mutation.md) | **required** | The Mutation definition describing the requested action                                                                       |
+| **options**            | _object_                        |              | An optional set of query options                                                                                              |
+| **options.variables**  | _object_                        |              | Variables to be passed to the dynamic portions of the mutation                                                                |
+| **options.onComplete** | _function_                      |              | Callback function to be called on successfull completion of the mutation. Called with the response data as the only argument. |
+| **options.onError**    | _function_                      |              | Callback function to be called on failure of the mutation. Called with the error instance as the only argument.               |
+| **options.lazy**       | _boolean_                       |              | If false, run the mutation immediately after the component mounts.<br/>_**Default**: `true`_                                  |
 
 ## Output
 
-|    Name     |                 Type                 | Description                                                                                                                                                                            |
-| :---------: | :----------------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **mutate**  |              _Function_              | This function can be called to execute the mutation. Any in-flight HTTP requests will automatically be aborted.                                                                        |
-| **called**  |              _boolean_               | **true** if the mutation has been triggered by a call to the `mutate` function or on component mount with `lazy: false`                                                                |
-| **loading** |              _boolean_               | **true** if the data is not yet available and no error has yet been encountered                                                                                                        |
-|  **error**  |    _Error_<br/>or<br/>_undefined_    | **undefined** if no error has occurred, otherwise the Error which was thrown                                                                                                           |
-|  **data**   | _QueryResult_<br/>or<br/>_undefined_ | **undefined** if the data is loading or an error has occurred, otherwise a map from the name of each **QueryDefinition** defined in the **Query** to the resulting data for that query |
-| **engine**  | [_Data Engine_](advanced/DataEngine) | A reference to the DataEngine instance                                                                                                                                                 |
+| Name        | Type                                 | Description                                                                                                                                                                            |
+| ----------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **mutate**  | _function_                           | This function can be called to execute the mutation. Any in-flight HTTP requests will automatically be aborted.                                                                        |
+| **called**  | _boolean_                            | **true** if the mutation has been triggered by a call to the `mutate` function or on component mount with `lazy: false`                                                                |
+| **loading** | _boolean_                            | **true** if the data is not yet available and no error has yet been encountered                                                                                                        |
+| **error**   | _Error_<br/>or<br/>_undefined_       | **undefined** if no error has occurred, otherwise the Error which was thrown                                                                                                           |
+| **data**    | _QueryResult_<br/>or<br/>_undefined_ | **undefined** if the data is loading or an error has occurred, otherwise a map from the name of each **QueryDefinition** defined in the **Query** to the resulting data for that query |
+| **engine**  | [_DataEngine_](advanced/DataEngine)  | A reference to the DataEngine instance                                                                                                                                                 |
 
 ## Example
 

--- a/docs/hooks/useDataQuery.md
+++ b/docs/hooks/useDataQuery.md
@@ -13,25 +13,25 @@ const { loading, error, data, refetch } = useDataQuery(query, options)
 
 ## Input
 
-|          Name          |          Type          |   Required   | Description                                                                                                                |
-| :--------------------: | :--------------------: | :----------: | -------------------------------------------------------------------------------------------------------------------------- |
-|       **query**        | [_Query_](types/Query) | **required** | The Query definition describing the requested data                                                                         |
-|      **options**       |        _Object_        |              | An optional set of query options                                                                                           |
-| **options.variables**  |        _Object_        |              | Variables to be passed to the dynamic portions of the query                                                                |
-| **options.onComplete** |       _Function_       |              | Callback function to be called on successfull completion of the query. Called with the response data as the only argument. |
-|  **options.onError**   |       _Function_       |              | Callback function to be called on failure of the query. Called with the error instance as the only argument.               |
-|    **options.lazy**    |       _boolean_        |              | If true, wait until `refetch` is called before fetching data.<br/>_**Default**: `false`_                                   |
+| Name                   | Type                   | Required     | Description                                                                                                                |
+| ---------------------- | ---------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| **query**              | [_Query_](types/Query) | **required** | The Query definition describing the requested data                                                                         |
+| **options**            | _object_               |              | An optional set of query options                                                                                           |
+| **options.variables**  | _object_               |              | Variables to be passed to the dynamic portions of the query                                                                |
+| **options.onComplete** | _function_             |              | Callback function to be called on successfull completion of the query. Called with the response data as the only argument. |
+| **options.onError**    | _function_             |              | Callback function to be called on failure of the query. Called with the error instance as the only argument.               |
+| **options.lazy**       | _boolean_              |              | If true, wait until `refetch` is called before fetching data.<br/>_**Default**: `false`_                                   |
 
 ## Output
 
-|    Name     |                 Type                 | Description                                                                                                                                                                            |
-| :---------: | :----------------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **called**  |              _boolean_               | **true** if the data request has been initiated with either `lazy: false` or `refetch()` at least once                                                                                 |
-| **loading** |              _boolean_               | **true** if the data is not yet available and no error has yet been encountered                                                                                                        |
-|  **error**  |    _Error_<br/>or<br/>_undefined_    | **undefined** if no error has occurred, otherwise the Error which was thrown                                                                                                           |
-|  **data**   | _QueryResult_<br/>or<br/>_undefined_ | **undefined** if the data is loading or an error has occurred, otherwise a map from the name of each **QueryDefinition** defined in the **Query** to the resulting data for that query |
-| **refetch** |              _Function_              | This function can be called to refetch the data. Any in-flight HTTP requests will automatically be aborted.                                                                            |
-| **engine**  | [_Data Engine_](advanced/DataEngine) | A reference to the DataEngine instance                                                                                                                                                 |
+| Name        | Type                                 | Description                                                                                                                                                                            |
+| ----------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **called**  | _boolean_                            | **true** if the data request has been initiated with either `lazy: false` or `refetch()` at least once                                                                                 |
+| **loading** | _boolean_                            | **true** if the data is not yet available and no error has yet been encountered                                                                                                        |
+| **error**   | _Error_<br/>or<br/>_undefined_       | **undefined** if no error has occurred, otherwise the Error which was thrown                                                                                                           |
+| **data**    | _QueryResult_<br/>or<br/>_undefined_ | **undefined** if the data is loading or an error has occurred, otherwise a map from the name of each **QueryDefinition** defined in the **Query** to the resulting data for that query |
+| **refetch** | _function_                           | This function can be called to refetch the data. Any in-flight HTTP requests will automatically be aborted.                                                                            |
+| **engine**  | [_DataEngine_](advanced/DataEngine)  | A reference to the DataEngine instance                                                                                                                                                 |
 
 ## Example
 

--- a/docs/types/Config.md
+++ b/docs/types/Config.md
@@ -4,7 +4,7 @@ The Application Config type is a required input to the top-level
 [Provider](provider), and can be accessed from within an application
 with the [useConfig](hooks/useConfig) hook.
 
-|    Property    |   Type   | Description                                                                                                     |
-| :------------: | :------: | --------------------------------------------------------------------------------------------------------------- |
-|  **baseUrl**   | _string_ | The base URL of the DHIS2 Core server, i.e. `https://play.dhis2.org/dev`                                        |
-| **apiVersion** | _number_ | The default API version to use. API request resource paths will be expanded to `{baseUrl}/api/{version}/{path}` |
+| Property       | Type     | Description                                                                                                        |
+| -------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| **baseUrl**    | _string_ | The base URL of the DHIS2 Core server, i.e. `https://play.dhis2.org/dev`                                           |
+| **apiVersion** | _number_ | The default API version to use. API request resource paths will be expanded to `{baseUrl}/api/{apiVersion}/{path}` |

--- a/docs/types/Mutation.md
+++ b/docs/types/Mutation.md
@@ -1,4 +1,4 @@
-# Mutation
+# Mutation Type
 
 The Mutation type is used to define declarative data mutations. It is required input for the [useDataMutation](hooks/useDataMutation.md) hook, [DataMutation](components/DataMutation.md) component, and [DataEngine.mutate](advanced/DataEngine) method.
 
@@ -6,14 +6,14 @@ A mutation defines a destructive operation performed on a collection or instance
 
 ## Properties
 
-|   Property   |              Type              |              | Description                                                                                                                                                |
-| :----------: | :----------------------------: | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|   **type**   |            _string_            | **required** | The type of mutation to perform, must be one of `create`, `update`, or `delete`.                                                                           |
-| **resource** |            _string_            | **required** | The path to the resource being requested, i.e. `indicators`.                                                                                               |
-|    **id**    | _string_ **or** _() => string_ |              | Required for `update` and `delete` mutations, not allowed for `create` mutations. Indicates that a particular **instance** of a collection will be mutated |
-| **partial**  |           _boolean_            |              | If performing an `update` mutation, set `partial: true` to replace only the provided fields of the target object.                                          |
-|  **params**  | _Object_ **or** _() => Object_ |              | A dictionary of properties which are translated into querystring parameters when the data is fetched                                                       |
-|   **data**   | _Object_ **or** _() => Object_ |              | The "body" of the mutation, the content of the newly created or updated resource. Disallowed for `delete` mutations                                        |
+| Property     | Type                           | Required     | Description                                                                                                                                                |
+| ------------ | ------------------------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **type**     | _string_                       | **required** | The type of mutation to perform, must be one of `create`, `update`, or `delete`.                                                                           |
+| **resource** | _string_                       | **required** | The path to the resource being requested, i.e. `indicators`.                                                                                               |
+| **id**       | _string_ **or** _() => string_ |              | Required for `update` and `delete` mutations, not allowed for `create` mutations. Indicates that a particular **instance** of a collection will be mutated |
+| **partial**  | _boolean_                      |              | If performing an `update` mutation, set `partial: true` to replace only the provided fields of the target object.                                          |
+| **params**   | _Object_ **or** _() => Object_ |              | A dictionary of properties which are translated into querystring parameters when the data is fetched                                                       |
+| **data**     | _Object_ **or** _() => Object_ |              | The "body" of the mutation, the content of the newly created or updated resource. Disallowed for `delete` mutations                                        |
 
 > See the [Mutation type definition](https://github.com/dhis2/app-runtime/blob/master/services/data/src/engine/types/Mutation.ts) for more information
 

--- a/docs/types/Query.md
+++ b/docs/types/Query.md
@@ -1,8 +1,6 @@
-# Data Queries
+# Query Type
 
 The Query type is used to define declarative data requests. It is required input for the [useDataQuery](hooks/useDataQuery.md) hook and [DataQuery](components/DataQuery.md) component.
-
-## Query
 
 A query is a map of names to **QueryDefinition** objects. The name can be any string. Multiple **QueryDefinition** components of a single **Query** will be fetched in parallel if possible.
 
@@ -18,10 +16,10 @@ const query = {
 
 ## QueryDefinition
 
-|   Property   |              Type              |              | Description                                                                                          |
-| :----------: | :----------------------------: | ------------ | ---------------------------------------------------------------------------------------------------- |
-| **resource** |            _string_            | **required** | The path to the resource being requested, i.e. `indicators`.                                         |
-|    **id**    | _string_ **or** _() => string_ |              | Optional, when specified indicates that a particular **instance** of a collection will be requested  |
-|  **params**  | _Object_ **or** _() => Object_ |              | A dictionary of properties which are translated into querystring parameters when the data is fetched |
+| Property     | Type                           | Required     | Description                                                                                          |
+| ------------ | ------------------------------ | ------------ | ---------------------------------------------------------------------------------------------------- |
+| **resource** | _string_                       | **required** | The path to the resource being requested, i.e. `indicators`.                                         |
+| **id**       | _string_ **or** _() => string_ |              | Optional, when specified indicates that a particular **instance** of a collection will be requested  |
+| **params**   | _Object_ **or** _() => Object_ |              | A dictionary of properties which are translated into querystring parameters when the data is fetched |
 
 > See the [Query type definition](https://github.com/dhis2/app-runtime/blob/master/services/data/src/engine/types/Query.ts) for more information

--- a/examples/cra/yarn.lock
+++ b/examples/cra/yarn.lock
@@ -1047,24 +1047,24 @@
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@dhis2/app-runtime@file:../../runtime":
-  version "2.8.0"
+  version "2.9.0"
   dependencies:
-    "@dhis2/app-service-alerts" "2.8.0"
-    "@dhis2/app-service-config" "2.8.0"
-    "@dhis2/app-service-data" "2.8.0"
-    "@dhis2/app-service-offline" "2.8.0"
+    "@dhis2/app-service-alerts" "2.9.0"
+    "@dhis2/app-service-config" "2.9.0"
+    "@dhis2/app-service-data" "2.9.0"
+    "@dhis2/app-service-offline" "2.9.0"
 
-"@dhis2/app-service-alerts@2.8.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "2.8.0"
+"@dhis2/app-service-alerts@2.9.0", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "2.9.0"
 
-"@dhis2/app-service-config@2.8.0", "@dhis2/app-service-config@file:../../services/config":
-  version "2.8.0"
+"@dhis2/app-service-config@2.9.0", "@dhis2/app-service-config@file:../../services/config":
+  version "2.9.0"
 
-"@dhis2/app-service-data@2.8.0", "@dhis2/app-service-data@file:../../services/data":
-  version "2.8.0"
+"@dhis2/app-service-data@2.9.0", "@dhis2/app-service-data@file:../../services/data":
+  version "2.9.0"
 
-"@dhis2/app-service-offline@2.8.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "2.8.0"
+"@dhis2/app-service-offline@2.9.0", "@dhis2/app-service-offline@file:../../services/offline":
+  version "2.9.0"
 
 "@hapi/address@2.x.x":
   version "2.1.4"

--- a/examples/query-playground/yarn.lock
+++ b/examples/query-playground/yarn.lock
@@ -1783,24 +1783,24 @@
     moment "^2.24.0"
 
 "@dhis2/app-runtime@*", "@dhis2/app-runtime@^2.2.2", "@dhis2/app-runtime@file:../../runtime":
-  version "2.8.0"
+  version "2.9.0"
   dependencies:
-    "@dhis2/app-service-alerts" "2.8.0"
-    "@dhis2/app-service-config" "2.8.0"
-    "@dhis2/app-service-data" "2.8.0"
-    "@dhis2/app-service-offline" "2.8.0"
+    "@dhis2/app-service-alerts" "2.9.0"
+    "@dhis2/app-service-config" "2.9.0"
+    "@dhis2/app-service-data" "2.9.0"
+    "@dhis2/app-service-offline" "2.9.0"
 
-"@dhis2/app-service-alerts@2.8.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "2.8.0"
+"@dhis2/app-service-alerts@2.9.0", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "2.9.0"
 
-"@dhis2/app-service-config@2.8.0", "@dhis2/app-service-config@file:../../services/config":
-  version "2.8.0"
+"@dhis2/app-service-config@2.9.0", "@dhis2/app-service-config@file:../../services/config":
+  version "2.9.0"
 
-"@dhis2/app-service-data@2.8.0", "@dhis2/app-service-data@file:../../services/data":
-  version "2.8.0"
+"@dhis2/app-service-data@2.9.0", "@dhis2/app-service-data@file:../../services/data":
+  version "2.9.0"
 
-"@dhis2/app-service-offline@2.8.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "2.8.0"
+"@dhis2/app-service-offline@2.9.0", "@dhis2/app-service-offline@file:../../services/offline":
+  version "2.9.0"
 
 "@dhis2/app-shell@5.2.0":
   version "5.2.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "devDependencies": {
         "@dhis2/cli-app-scripts": "^6.2.0",
         "@dhis2/cli-style": "^7.2.2",
-        "@dhis2/cli-utils-docsite": "^2.0.3",
+        "@dhis2/cli-utils-docsite": "^3.1.2",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.0.0",
         "@testing-library/react-hooks": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,12 +16,12 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.5.5":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
-  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5", "@babel/code-frame@^7.5.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
   dependencies:
-    "@babel/highlight" "^7.12.13"
+    "@babel/highlight" "^7.14.5"
 
 "@babel/compat-data@^7.12.1", "@babel/compat-data@^7.13.0", "@babel/compat-data@^7.13.5":
   version "7.13.6"
@@ -72,12 +72,12 @@
     semver "7.0.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.12.1", "@babel/generator@^7.13.0", "@babel/generator@^7.4.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.0.tgz#bd00d4394ca22f220390c56a0b5b85568ec1ec0c"
-  integrity sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==
+"@babel/generator@^7.12.1", "@babel/generator@^7.12.11", "@babel/generator@^7.13.0", "@babel/generator@^7.15.0", "@babel/generator@^7.4.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.0.tgz#a7d0c172e0d814974bad5aa77ace543b97917f15"
+  integrity sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==
   dependencies:
-    "@babel/types" "^7.13.0"
+    "@babel/types" "^7.15.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -146,29 +146,28 @@
   dependencies:
     "@babel/types" "^7.13.0"
 
-"@babel/helper-function-name@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
-  integrity sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
+"@babel/helper-function-name@^7.12.13", "@babel/helper-function-name@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
+  integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.12.13"
-    "@babel/template" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/helper-get-function-arity" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-get-function-arity@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583"
-  integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
+"@babel/helper-get-function-arity@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
+  integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-hoist-variables@^7.12.13":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz#5d5882e855b5c5eda91e0cadc26c6e7a2c8593d8"
-  integrity sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==
+"@babel/helper-hoist-variables@^7.12.13", "@babel/helper-hoist-variables@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
+  integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
   dependencies:
-    "@babel/traverse" "^7.13.0"
-    "@babel/types" "^7.13.0"
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-member-expression-to-functions@^7.13.0":
   version "7.13.0"
@@ -251,17 +250,17 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-split-export-declaration@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
-  integrity sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
+"@babel/helper-split-export-declaration@^7.12.13", "@babel/helper-split-export-declaration@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
+  integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-validator-identifier@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
-  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+"@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
+  version "7.14.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
+  integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
 
 "@babel/helper-validator-option@^7.12.1", "@babel/helper-validator-option@^7.12.17":
   version "7.12.17"
@@ -287,19 +286,19 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
-  integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
+  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
+    "@babel/helper-validator-identifier" "^7.14.5"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.12.3", "@babel/parser@^7.13.0", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.9.4":
-  version "7.13.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.4.tgz#340211b0da94a351a6f10e63671fa727333d13ab"
-  integrity sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.3", "@babel/parser@^7.13.0", "@babel/parser@^7.14.5", "@babel/parser@^7.15.0", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.9.4":
+  version "7.15.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.3.tgz#3416d9bea748052cfcb63dbcc27368105b1ed862"
+  integrity sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==
 
 "@babel/plugin-proposal-async-generator-functions@^7.12.1", "@babel/plugin-proposal-async-generator-functions@^7.13.5":
   version "7.13.5"
@@ -1125,36 +1124,36 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
-  version "7.13.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.7.tgz#d494e39d198ee9ca04f4dcb76d25d9d7a1dc961a"
-  integrity sha512-h+ilqoX998mRVM5FtB5ijRuHUDVt5l3yfoOi2uh18Z/O3hvyaHQ39NpxVkCIG5yFs+mLq/ewFp8Bss6zmWv6ZA==
+"@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+  version "7.15.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
+  integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
-  integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
+"@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.14.5", "@babel/template@^7.3.3", "@babel/template@^7.4.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
+  integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
   dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/parser" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.12.1", "@babel/traverse@^7.13.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.7.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.0.tgz#6d95752475f86ee7ded06536de309a65fc8966cc"
-  integrity sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.1.6", "@babel/traverse@^7.12.1", "@babel/traverse@^7.13.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.7.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.0.tgz#4cca838fd1b2a03283c1f38e141f639d60b3fc98"
+  integrity sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==
   dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.13.0"
-    "@babel/helper-function-name" "^7.12.13"
-    "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/parser" "^7.13.0"
-    "@babel/types" "^7.13.0"
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.0"
+    "@babel/helper-function-name" "^7.14.5"
+    "@babel/helper-hoist-variables" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/parser" "^7.15.0"
+    "@babel/types" "^7.15.0"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.19"
 
 "@babel/types@7.8.3":
   version "7.8.3"
@@ -1165,13 +1164,12 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.17", "@babel/types@^7.12.5", "@babel/types@^7.12.6", "@babel/types@^7.13.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.0.tgz#74424d2816f0171b4100f0ab34e9a374efdf7f80"
-  integrity sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
+"@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.17", "@babel/types@^7.12.5", "@babel/types@^7.12.6", "@babel/types@^7.13.0", "@babel/types@^7.14.5", "@babel/types@^7.15.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.0.tgz#61af11f2286c4e9c69ca8deb5f4375a73c72dcbd"
+  integrity sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
-    lodash "^4.17.19"
+    "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1420,15 +1418,30 @@
     update-notifier "^3.0.0"
     yargs "^13.1.0"
 
-"@dhis2/cli-helpers-template@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-template/-/cli-helpers-template-1.0.2.tgz#537904af58f0965e67a5b490fb2737c148ff24d0"
-  integrity sha512-kXSgK0MqeyIpOemJf2fJNQzjcpbW3IvESeICguvVo0wmChFz1i4EaXEG18NI0hhrICilqk2ci8sizkBP+fMV/A==
+"@dhis2/cli-helpers-engine@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-engine/-/cli-helpers-engine-3.0.0.tgz#dacddea16de7e5e60280aefbee2e5661795b78b3"
+  integrity sha512-e8cZFFsunQp56iLx1FKBWGZ1tmWOjdbqJaBwOnzvsKPyYopV9RzNcPm+HIBwfnCjHBWoWTf6ijaf3xVnimZC2w==
+  dependencies:
+    chalk "^3.0.0"
+    cross-spawn "^7.0.3"
+    find-up "^5.0.0"
+    fs-extra "^8.0.1"
+    inquirer "^7.3.3"
+    request "^2.88.0"
+    tar "^4.4.8"
+    update-notifier "^3.0.0"
+    yargs "^13.1.0"
+
+"@dhis2/cli-helpers-template@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-template/-/cli-helpers-template-3.0.0.tgz#1cfb625a6e1a6a824386bd0cfd3ba646783920c3"
+  integrity sha512-CPjXG3By9uf2dNb1DsziAuwTPM125QbTMGY9t9J97hBhpy7Y1xnChaoXAxhpdOEHKENwbox6blYKf1GrWeFAkw==
   dependencies:
     "@dhis2/cli-helpers-engine" "^1.5.0"
     fs-extra "^8.1.0"
-    handlebars "^4.5.3"
-    isbinaryfile "^4.0.2"
+    handlebars "^4.7.3"
+    isbinaryfile "^4.0.4"
 
 "@dhis2/cli-style@^7.2.2":
   version "7.3.0"
@@ -1454,19 +1467,25 @@
     semver "^7.3.2"
     yargs "^16.1.0"
 
-"@dhis2/cli-utils-docsite@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-utils-docsite/-/cli-utils-docsite-2.0.3.tgz#e76dcb709e3c175548001c70ded3fc371f1f6540"
-  integrity sha512-WSfP6P41EYZkN3WV7THTu2v2QHxvtTm52XqxCP+KOk0qi+RvUDk2UOUSkDAiApgTQKyALcY3u4JQrq1ThH5Pyw==
+"@dhis2/cli-utils-docsite@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-utils-docsite/-/cli-utils-docsite-3.1.2.tgz#ee67683b1611ae684cd6ab2f29a61b5fd1f2d31a"
+  integrity sha512-0gyXG8fcVt5qtvGlDaGY+q4F3He0Z8lD2nI4uVNkNJY0IMOCVIodeQT1WN8OZOl/R0tTGKTQui0T1XueyFsiLg==
   dependencies:
-    "@dhis2/cli-helpers-engine" "^1.5.0"
-    "@dhis2/cli-helpers-template" "^1.0.2"
+    "@dhis2/cli-helpers-engine" "^3.0.0"
+    "@dhis2/cli-helpers-template" "^3.0.0"
+    ast-types "^0.14.2"
     chokidar "^3.3.1"
     front-matter "^3.1.0"
     fs-extra "^8.1.0"
+    glob "^7.1.7"
+    hyperscript-html "^2.0.0"
     jsdoc-to-markdown "^5.0.3"
     live-server "^1.2.1"
+    marked "^2.1.3"
     match-all "^1.2.5"
+    react-docgen "^6.0.0-alpha.0"
+    url-join "^4.0.1"
 
 "@dhis2/d2-i18n@^1.1.0":
   version "1.1.0"
@@ -2142,21 +2161,7 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@*":
-  version "7.29.6"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.6.tgz#eb37844fb431186db7960a7ff6749ea65a19617c"
-  integrity sha512-vzTsAXa439ptdvav/4lsKRcGpAQX7b6wBIqia7+iNzqGJ5zjswApxA6jDAsexrc6ue9krWcbh8o+LYkBXW+GCQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.4"
-    lz-string "^1.4.4"
-    pretty-format "^26.6.2"
-
-"@testing-library/dom@^8.0.0":
+"@testing-library/dom@*", "@testing-library/dom@^8.0.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.1.0.tgz#f8358b1883844ea569ba76b7e94582168df5370d"
   integrity sha512-kmW9alndr19qd6DABzQ978zKQ+J65gU2Rzkl8hriIetPnwpesRaK4//jEQyYh8fEALmGhomD/LBQqt+o+DL95Q==
@@ -2408,15 +2413,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
-  integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=16.9.0":
+"@types/react@*", "@types/react@>=16.9.0":
   version "17.0.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.14.tgz#f0629761ca02945c4e8fea99b8177f4c5c61fb0f"
   integrity sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==
@@ -3324,6 +3321,13 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
+ast-types@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
+  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+  dependencies:
+    tslib "^2.0.1"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -4011,6 +4015,24 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
+c8@^7.6.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/c8/-/c8-7.8.0.tgz#8fcfe848587d9d5796f22e9b0546a387a66d1b3b"
+  integrity sha512-x2Bx+IIEd608B1LmjiNQ/kizRPkCWo5XzuV57J9afPjAHSnYXALwbCSOkQ7cSaNXBNblfqcvdycj+klmL+j6yA==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@istanbuljs/schema" "^0.1.2"
+    find-up "^5.0.0"
+    foreground-child "^2.0.0"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-reports "^3.0.2"
+    rimraf "^3.0.0"
+    test-exclude "^6.0.0"
+    v8-to-istanbul "^8.0.0"
+    yargs "^16.2.0"
+    yargs-parser "^20.2.7"
+
 cacache@^12.0.2:
   version "12.0.4"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.4.tgz#668bcbd105aeb5f1d92fe25570ec9525c8faa40c"
@@ -4309,12 +4331,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.6:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
-
-classnames@^2.3.1:
+classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
@@ -5526,11 +5543,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
-  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
-
 dom-accessibility-api@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz#3f5d43b52c7a3bd68b5fb63fa47b4e4c1fdf65a9"
@@ -6160,6 +6172,15 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
+estree-to-babel@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/estree-to-babel/-/estree-to-babel-3.2.1.tgz#82e78315275c3ca74475fdc8ac1a5103c8a75bf5"
+  integrity sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==
+  dependencies:
+    "@babel/traverse" "^7.1.6"
+    "@babel/types" "^7.2.0"
+    c8 "^7.6.0"
+
 estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
@@ -6674,6 +6695,14 @@ for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
+foreground-child@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"
+  integrity sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^3.0.2"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -6985,10 +7014,10 @@ glob-stream@^6.1.0:
     to-absolute-glob "^2.0.0"
     unique-stream "^2.0.2"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.5, glob@^7.1.6, glob@~7.1.1:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.5, glob@^7.1.6, glob@^7.1.7, glob@~7.1.1:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -7150,7 +7179,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars@^4.3.3, handlebars@^4.5.3:
+handlebars@^4.3.3, handlebars@^4.5.3, handlebars@^4.7.3:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -7502,6 +7531,13 @@ husky@^4.3.0:
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
+
+hyperscript-html@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hyperscript-html/-/hyperscript-html-2.0.0.tgz#02cc9ba3040853ed311d70bb30630cc73ccb0bbd"
+  integrity sha512-y6MgsjwGkBL8Pm/8RYVe/3Tu1gpBoymJjPNrtGuIRyjXVCm2p1iqA5gA98bRZOBrJO+7QaEPOD09oqqzhqkEnQ==
+  dependencies:
+    zenhand "^2.0.0"
 
 i18next-conv@^9:
   version "9.2.1"
@@ -8163,10 +8199,10 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isbinaryfile@^4.0.2:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.6.tgz#edcb62b224e2b4710830b67498c8e4e5a4d2610b"
-  integrity sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==
+isbinaryfile@^4.0.4:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.8.tgz#5d34b94865bd4946633ecc78a026fc76c5b11fcf"
+  integrity sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -9805,6 +9841,11 @@ marked@^0.8.2:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
   integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
 
+marked@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
+  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
+
 match-all@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/match-all/-/match-all-1.2.6.tgz#66d276ad6b49655551e63d3a6ee53e8be0566f8d"
@@ -9998,7 +10039,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.4, minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -10243,6 +10284,13 @@ no-case@^3.0.4:
   dependencies:
     lower-case "^2.0.2"
     tslib "^2.0.3"
+
+node-dir@^0.1.10:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
+  integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=
+  dependencies:
+    minimatch "^3.0.2"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -12089,6 +12137,23 @@ react-dev-utils@^11.0.3:
     shell-quote "1.7.2"
     strip-ansi "6.0.0"
     text-table "0.2.0"
+
+react-docgen@^6.0.0-alpha.0:
+  version "6.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-6.0.0-alpha.0.tgz#62bbedb63e5cf43e13957dc84cd9d7c3a4acb2ed"
+  integrity sha512-x04mIC8H6sLypv0bA87WW5hKmJXXM48aHaw5XD44LHcb+IqF3eL1Ev0YtXzxb7BXCoXV/WzpzCTuaqjUA39dyw==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@babel/generator" "^7.12.11"
+    "@babel/runtime" "^7.7.6"
+    ast-types "^0.14.2"
+    commander "^2.19.0"
+    doctrine "^3.0.0"
+    estree-to-babel "^3.1.0"
+    neo-async "^2.6.1"
+    node-dir "^0.1.10"
+    resolve "^1.17.0"
+    strip-indent "^3.0.0"
 
 react-dom@^16.12.0, react-dom@^16.8.6:
   version "16.14.0"
@@ -14299,10 +14364,10 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+tslib@^2.0.1, tslib@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.20.0"
@@ -14587,6 +14652,11 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
+
 url-loader@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"
@@ -14701,6 +14771,15 @@ v8-to-istanbul@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz#5b95cef45c0f83217ec79f8fc7ee1c8b486aee07"
   integrity sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^1.6.0"
+    source-map "^0.7.3"
+
+v8-to-istanbul@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz#4229f2a99e367f3f018fa1d5c2b8ec684667c69c"
+  integrity sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
@@ -14846,8 +14925,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
@@ -15411,10 +15492,10 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.2.2, yargs-parser@^20.2.3:
-  version "20.2.6"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.6.tgz#69f920addf61aafc0b8b89002f5d66e28f2d8b20"
-  integrity sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==
+yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.7:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs@^13.1.0, yargs@^13.3.0, yargs@^13.3.2:
   version "13.3.2"
@@ -15483,6 +15564,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zenhand@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/zenhand/-/zenhand-2.0.0.tgz#a82c0b3b14016da1888f6e3f38647fe06ad7aa21"
+  integrity sha512-V5f/NlynoAFc+dRU/+uJTgf4vox3yHfJlnvP5BAJ6sZFNR2RTpyUMcUDBklTDHo6YiZhwj6WzZeOs+FOcMdq2A==
 
 zip-stream@^2.1.2:
   version "2.1.3"


### PR DESCRIPTION
Ensures our documentation is consistent for each hook, type and service.

Also bumps `cli-utils-docsite` to benefit from stylesheet changes.