### PR TITLE
fix: update state when id arg changes

### DIFF
--- a/services/offline/src/lib/__tests__/use-cacheable-section.test.tsx
+++ b/services/offline/src/lib/__tests__/use-cacheable-section.test.tsx
@@ -214,3 +214,36 @@ it('handles remove and updates sections', async () => {
     expect(result.current.isCached).toBe(false)
     expect(result.current.lastUpdated).toBeUndefined()
 })
+
+it('handles a change in ID', async () => {
+    const testOfflineInterface = {
+        ...mockOfflineInterface,
+        getCachedSections: jest
+            .fn()
+            .mockResolvedValue([
+                { sectionId: 'id-one', lastUpdated: new Date() },
+            ]),
+    }
+    const { result, waitFor, rerender } = renderHook(
+        (...args) => useCacheableSection(...args),
+        {
+            wrapper: ({ children }) => (
+                <OfflineProvider offlineInterface={testOfflineInterface}>
+                    {children}
+                </OfflineProvider>
+            ),
+            initialProps: 'id-one',
+        }
+    )
+
+    // Wait for state to sync with indexedDB
+    await waitFor(() => result.current.isCached === true)
+
+    rerender('id-two')
+
+    // Test that 'isCached' gets updated
+    // expect(testOfflineInterface.getCachedSections).toBeCalledTimes(2)
+    await waitFor(() => result.current.isCached === false)
+    expect(result.current.isCached).toBe(false)
+    expect(result.current.lastUpdated).toBeUndefined()
+})

--- a/services/offline/src/lib/global-state-service.tsx
+++ b/services/offline/src/lib/global-state-service.tsx
@@ -75,8 +75,10 @@ export const useGlobalState = (
                 setSelectedState(newSelectedState)
         }
         store.subscribe(callback)
+        // Make sure to update state when selector changes
+        callback(store.getState())
         return () => store.unsubscribe(callback)
-    }, [store]) /* eslint-disable-line react-hooks/exhaustive-deps */
+    }, [store, selector]) /* eslint-disable-line react-hooks/exhaustive-deps */
 
     return [selectedState, store.mutate]
 }


### PR DESCRIPTION
@jenniferarnesen encountered an issue in the Dashboards app where the `isCached` status was not updating when clicking between dashboards. I traced the issue back to the `useGlobalState` hook, which did not update its selected state when the `selector` prop changed, so I update the 'useEffect' hook to do so