### PR TITLE
fix: handle debouncing across rerenders

### DIFF
--- a/services/offline/package.json
+++ b/services/offline/package.json
@@ -37,5 +37,8 @@
         "prop-types": "^15.7.2",
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
+    },
+    "dependencies": {
+        "lodash": "^4.17.21"
     }
 }

--- a/services/offline/package.json
+++ b/services/offline/package.json
@@ -37,8 +37,5 @@
         "prop-types": "^15.7.2",
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
-    },
-    "dependencies": {
-        "use-debounce": "^7.0.0"
     }
 }

--- a/services/offline/package.json
+++ b/services/offline/package.json
@@ -37,5 +37,8 @@
         "prop-types": "^15.7.2",
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
+    },
+    "dependencies": {
+        "use-debounce": "^7.0.0"
     }
 }

--- a/services/offline/src/lib/__tests__/online-status.test.tsx
+++ b/services/offline/src/lib/__tests__/online-status.test.tsx
@@ -1,8 +1,16 @@
+import { render, screen, waitFor } from '@testing-library/react'
 import { act, renderHook } from '@testing-library/react-hooks'
+import React from 'react'
 import { useOnlineStatus } from '../online-status'
 
 interface CapturedEventListeners {
     [index: string]: EventListener
+}
+
+function wait(ms: number): Promise<void> {
+    return new Promise(resolve => {
+        setTimeout(() => resolve(), ms)
+    })
 }
 
 beforeEach(() => {
@@ -171,5 +179,122 @@ describe('debouncing state changes', () => {
         // 50ms later, final "online" event should finally resolve
         await waitForNextUpdate({ timeout: 60 })
         expect(result.current.online).toBe(true)
+    })
+
+    it('handles debounced state change when parent component rerenders during a debounce delay', async () => {
+        jest.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(true)
+        const events: CapturedEventListeners = {}
+        window.addEventListener = jest.fn(
+            (event, cb) => (events[event] = cb as EventListener)
+        )
+
+        const TestComponent = () => {
+            const { online } = useOnlineStatus({ debounceDelay: 50 })
+            return <div data-testid="status">{online ? 'on' : 'off'}</div>
+        }
+        const { rerender } = render(<TestComponent />)
+
+        const { getByTestId } = screen
+        expect(getByTestId('status')).toHaveTextContent('on')
+
+        await act(async () => {
+            // Multiple events in succession
+            events.offline(new Event('offline'))
+            events.online(new Event('online'))
+            events.offline(new Event('offline'))
+        })
+
+        // Immediately, nothing should happen
+        expect(getByTestId('status')).toHaveTextContent('on')
+
+        // Rerender parent component
+        rerender(<TestComponent />)
+
+        // Final "offline" event should still resolve
+        await waitFor(() =>
+            expect(getByTestId('status')).toHaveTextContent('off')
+        )
+    })
+
+    it('handles debounced state change when parent component rerenders during a debounce delay', async () => {
+        jest.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(true)
+        const events: CapturedEventListeners = {}
+        window.addEventListener = jest.fn(
+            (event, cb) => (events[event] = cb as EventListener)
+        )
+
+        const TestComponent = ({ options }: { options?: any }) => {
+            const { online } = useOnlineStatus(options)
+            return <div data-testid="status">{online ? 'on' : 'off'}</div>
+        }
+        const { rerender } = render(<TestComponent />)
+
+        const { getByTestId } = screen
+        expect(getByTestId('status')).toHaveTextContent('on')
+
+        await act(async () => {
+            // Multiple events in succession
+            events.offline(new Event('offline'))
+            events.online(new Event('online'))
+            events.offline(new Event('offline'))
+        })
+
+        // Immediately, nothing should happen
+        expect(getByTestId('status')).toHaveTextContent('on')
+
+        // Change debounce options
+        rerender(<TestComponent options={{ debounceDelay: 50 }} />)
+
+        // Final "offline" event should still resolve
+        await waitFor(() =>
+            expect(getByTestId('status')).toHaveTextContent('off')
+        )
+    })
+
+    it('debounces consistently across rerenders', async () => {
+        jest.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(true)
+        const events: CapturedEventListeners = {}
+        window.addEventListener = jest.fn(
+            (event, cb) => (events[event] = cb as EventListener)
+        )
+
+        const TestComponent = () => {
+            const { online } = useOnlineStatus({ debounceDelay: 100 })
+            return <div data-testid="status">{online ? 'on' : 'off'}</div>
+        }
+        const { rerender } = render(<TestComponent />)
+
+        const { getByTestId } = screen
+        expect(getByTestId('status')).toHaveTextContent('on')
+
+        await act(async () => {
+            // Multiple events in succession
+            events.offline(new Event('offline'))
+            events.online(new Event('online'))
+            events.offline(new Event('offline'))
+        })
+
+        // wait a little bit - not long enough for debounce to resolve
+        await wait(50)
+        expect(getByTestId('status')).toHaveTextContent('on')
+
+        // Rerender parent component
+        rerender(<TestComponent />)
+
+        // Trigger more events
+        await act(async () => {
+            events.online(new Event('online'))
+            events.offline(new Event('offline'))
+        })
+
+        // wait a little more - long enough that the first debounced callbacks
+        // _would_ have resolved if there weren't the second set of events
+        await wait(60)
+        expect(getByTestId('status')).toHaveTextContent('on')
+
+        // wait long enough for second set of callbacks to resolve
+        await waitFor(() =>
+            expect(getByTestId('status')).toHaveTextContent('off')
+        )
     })
 })

--- a/services/offline/src/lib/__tests__/online-status.test.tsx
+++ b/services/offline/src/lib/__tests__/online-status.test.tsx
@@ -216,7 +216,7 @@ describe('debouncing state changes', () => {
         )
     })
 
-    it('handles debounced state change when parent component rerenders during a debounce delay', async () => {
+    it('handles debounced state change when debounce delay is changed during a delay', async () => {
         jest.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(true)
         const events: CapturedEventListeners = {}
         window.addEventListener = jest.fn(
@@ -227,7 +227,9 @@ describe('debouncing state changes', () => {
             const { online } = useOnlineStatus(options)
             return <div data-testid="status">{online ? 'on' : 'off'}</div>
         }
-        const { rerender } = render(<TestComponent />)
+        const { rerender } = render(
+            <TestComponent options={{ debounceDelay: 100 }} />
+        )
 
         const { getByTestId } = screen
         expect(getByTestId('status')).toHaveTextContent('on')

--- a/services/offline/src/lib/online-status.ts
+++ b/services/offline/src/lib/online-status.ts
@@ -44,6 +44,7 @@ export function useOnlineStatus(
         window.addEventListener('online', updateState)
         window.addEventListener('offline', updateState)
         return () => {
+            updateState.flush()
             window.removeEventListener('online', updateState)
             window.removeEventListener('offline', updateState)
         }

--- a/services/offline/src/lib/online-status.ts
+++ b/services/offline/src/lib/online-status.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
-import { useDebouncedCallback } from 'use-debounce'
+import debounce from 'lodash/debounce'
+import { useState, useEffect, useCallback } from 'react'
 
 type milliseconds = number
 interface OnlineStatusOptions {
@@ -24,13 +24,19 @@ interface OnlineStatus {
  * @param {Number} [options.debounceDelay] - Timeout delay to debounce updates, in ms
  * @returns {Object} `{ online, offline }` booleans. Each is the opposite of the other.
  */
-export function useOnlineStatus(options?: OnlineStatusOptions): OnlineStatus {
+export function useOnlineStatus(
+    options: OnlineStatusOptions = {}
+): OnlineStatus {
     // initialize state to `navigator.onLine` value
     const [online, setOnline] = useState(navigator.onLine)
 
-    const updateState = useDebouncedCallback(
-        ({ type }: Event) => setOnline(type === 'online'),
-        options?.debounceDelay || 1000
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const updateState = useCallback(
+        debounce(
+            ({ type }: Event) => setOnline(type === 'online'),
+            options.debounceDelay || 1000
+        ),
+        [options.debounceDelay]
     )
 
     // on 'online' or 'offline' events, set state

--- a/services/offline/src/lib/online-status.ts
+++ b/services/offline/src/lib/online-status.ts
@@ -1,5 +1,5 @@
-import debounce from 'lodash/debounce'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
 
 type milliseconds = number
 interface OnlineStatusOptions {
@@ -28,13 +28,9 @@ export function useOnlineStatus(options?: OnlineStatusOptions): OnlineStatus {
     // initialize state to `navigator.onLine` value
     const [online, setOnline] = useState(navigator.onLine)
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const updateState = useCallback(
-        debounce(
-            ({ type }: Event) => setOnline(type === 'online'),
-            options?.debounceDelay || 1000
-        ),
-        [options]
+    const updateState = useDebouncedCallback(
+        ({ type }: Event) => setOnline(type === 'online'),
+        options?.debounceDelay || 1000
     )
 
     // on 'online' or 'offline' events, set state
@@ -42,7 +38,6 @@ export function useOnlineStatus(options?: OnlineStatusOptions): OnlineStatus {
         window.addEventListener('online', updateState)
         window.addEventListener('offline', updateState)
         return () => {
-            updateState.cancel()
             window.removeEventListener('online', updateState)
             window.removeEventListener('offline', updateState)
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14619,6 +14619,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-debounce@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-7.0.0.tgz#00a67d23d4fe09905e11145a99278da06c01c880"
+  integrity sha512-4fvxEEs7ztdNMh+c497HAgysdq2+Ascem6EaDANGlCIap1JzqfL03Xw8xkYc2lShfXm4uO6PA6V5zcXN7gJdFA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9642,7 +9642,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.5, lodash@~4.17.10:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.2, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14619,11 +14619,6 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-debounce@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-7.0.0.tgz#00a67d23d4fe09905e11145a99278da06c01c880"
-  integrity sha512-4fvxEEs7ztdNMh+c497HAgysdq2+Ascem6EaDANGlCIap1JzqfL03Xw8xkYc2lShfXm4uO6PA6V5zcXN7gJdFA==
-
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
@mediremi noticed that the recent fix to `useOnlineStatus` also introduced an issue where the online status state might not update if the component consuming the hook rerenders in the middle of a debounce delay due to the `debouncedFunction.cancel()` call in the `useEffect` cleanup.

~~The `use-debounce` library is used here to handle debouncing and callbacks in a more robust way~~. Instead, `options.debounceDelay` was added as a dependency to the `useCallback` hook.