### PR TITLE
feat: track 'last online' time in localStorage

### DIFF
--- a/services/offline/src/lib/__tests__/online-status.test.tsx
+++ b/services/offline/src/lib/__tests__/online-status.test.tsx
@@ -372,7 +372,8 @@ describe('it updates the lastOnline value in local storage', () => {
         )
     })
 
-    it("sets lastOnline on mount if it's not set", () => {
+    // not necessary
+    it.skip("sets lastOnline on mount if it's not set", () => {
         jest.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(false)
         const events: CapturedEventListeners = {}
         window.addEventListener = jest.fn(

--- a/services/offline/src/lib/__tests__/online-status.test.tsx
+++ b/services/offline/src/lib/__tests__/online-status.test.tsx
@@ -372,6 +372,26 @@ describe('it updates the lastOnline value in local storage', () => {
         )
     })
 
+    it("sets lastOnline on mount if it's not set", () => {
+        jest.spyOn(navigator, 'onLine', 'get').mockReturnValueOnce(false)
+        const events: CapturedEventListeners = {}
+        window.addEventListener = jest.fn(
+            (event, cb) => (events[event] = cb as EventListener)
+        )
+        const { result } = renderHook((...args) => useOnlineStatus(...args), {
+            initialProps: { debounceDelay: 0 },
+        })
+
+        const parsedDate = new Date(
+            localStorage.getItem(lastOnlineKey) as string
+        )
+        expect(parsedDate.toString()).not.toBe('Invalid Date')
+        expect(result.current.lastOnline).toBeInstanceOf(Date)
+        expect(result.current.lastOnline?.toUTCString()).toBe(
+            localStorage.getItem(lastOnlineKey)
+        )
+    })
+
     it("doesn't change lastOnline it exists and if it's already offline", async () => {
         // seed localStorage
         localStorage.setItem(lastOnlineKey, testDateString)

--- a/services/offline/src/lib/online-status.ts
+++ b/services/offline/src/lib/online-status.ts
@@ -51,7 +51,7 @@ export function useOnlineStatus(
                 }
                 setOnline(false)
             }
-        }, options.debounceDelay || 1000),
+        }, options.debounceDelay ?? 1000),
         [options.debounceDelay]
     )
 

--- a/services/offline/src/lib/online-status.ts
+++ b/services/offline/src/lib/online-status.ts
@@ -10,6 +10,8 @@ interface OnlineStatus {
     online: boolean
     offline: boolean
     lastOnline: Date | null
+    // todo: remove
+    localStorageVal: string | null
 }
 
 const lastOnlineKey = 'dhis2.lastOnline'

--- a/services/offline/src/lib/online-status.ts
+++ b/services/offline/src/lib/online-status.ts
@@ -1,5 +1,5 @@
 import debounce from 'lodash/debounce'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 
 type milliseconds = number
 interface OnlineStatusOptions {
@@ -67,7 +67,10 @@ export function useOnlineStatus(
     }, [updateState])
 
     // Only fetch if `online === false` as local storage is synchronous and disk-based
-    const lastOnline = !online && localStorage.getItem(lastOnlineKey)
+    const lastOnline = useMemo(
+        () => !online && localStorage.getItem(lastOnlineKey),
+        [online]
+    )
 
     return {
         online,

--- a/services/offline/src/lib/online-status.ts
+++ b/services/offline/src/lib/online-status.ts
@@ -10,8 +10,6 @@ interface OnlineStatus {
     online: boolean
     offline: boolean
     lastOnline: Date | null
-    // todo: remove
-    localStorageVal: string | null
 }
 
 const lastOnlineKey = 'dhis2.lastOnline'
@@ -26,12 +24,12 @@ const lastOnlineKey = 'dhis2.lastOnline'
  * `options.debounceDelay` param.
  *
  * On state change, updates the `dhis2.lastOnline` property in local storage
- * for consuming apps to format and display.
+ * for consuming apps to format and display. Returns `lastOnline` as `null` if
+ * online or as a Date if offline.
  *
  * @param {Object} [options]
  * @param {Number} [options.debounceDelay] - Timeout delay to debounce updates, in ms
- * todo: update return value
- * @returns {Object} `{ online, offline }` booleans. Each is the opposite of the other.
+ * @returns {Object} `{ online: boolean, offline: boolean, lastOnline: Date | null }`
  */
 export function useOnlineStatus(
     options: OnlineStatusOptions = {}
@@ -45,13 +43,13 @@ export function useOnlineStatus(
             if (type === 'online') {
                 setOnline(true)
             } else if (type === 'offline') {
-                setOnline(false)
-                if (!localStorage.getItem(lastOnlineKey)) {
+                if (online || !localStorage.getItem(lastOnlineKey)) {
                     localStorage.setItem(
                         lastOnlineKey,
                         new Date(Date.now()).toUTCString()
                     )
                 }
+                setOnline(false)
             }
         }, options.debounceDelay || 1000),
         [options.debounceDelay]
@@ -75,7 +73,5 @@ export function useOnlineStatus(
         online,
         offline: !online,
         lastOnline: lastOnline ? new Date(lastOnline) : null,
-        // for testing purposes:
-        localStorageVal: localStorage.getItem(lastOnlineKey),
     }
 }


### PR DESCRIPTION
This feature can be used by apps or the header bar to display the 'last online' status. It's stored in `localStorage` so that the value can persist between sessions and be used between apps (although it will only be updated in apps that use PWA or use the most recent UI with the new header bar).

In the tests, I tried mocking the `Date` class and `Date.now()`, but both approaches either had issues with typescript or would make the test fail for mysterious reasons :( 