### PR TITLE
fix(offline): return correct value from clearSensitiveCaches

### DIFF
--- a/services/offline/src/lib/clear-sensitive-caches.ts
+++ b/services/offline/src/lib/clear-sensitive-caches.ts
@@ -66,13 +66,14 @@ export async function clearSensitiveCaches(
 
     const cacheKeys = await caches.keys()
     return Promise.all([
-        clearDB(dbName),
-        // remove caches if not in keepable list
+        // (Resolves to 'false' because this can't detect if anything was deleted):
+        clearDB(dbName).then(() => false),
+        // Remove caches if not in keepable list
         ...cacheKeys.map(key => {
             if (!KEEPABLE_CACHES.some(pattern => pattern.test(key))) {
-                // .then() satisfies typescript
-                return caches.delete(key).then(() => undefined)
+                return caches.delete(key)
             }
+            return false
         }),
     ]).then(responses => {
         // Return true if any caches have been cleared


### PR DESCRIPTION
Previously, when clearSensitiveCaches didn't resolve to a relevant value, `caches.delete(key).then(() => undefined)` was returned in `Promise.all` to satisfy typescript, but I forgot to remove the `undefined` resolution when I copied in a refactor from the app platform that made `clearSensitiveCaches` resolve to a boolean indicating if any caches were deleted. Fixed that and some tests so that it resolves to the right boolean 👍 