### PR TITLE
feat(data-service): add json-patch support

### DIFF
--- a/docs/types/Mutation.md
+++ b/docs/types/Mutation.md
@@ -8,7 +8,7 @@ A mutation defines a destructive operation performed on a collection or instance
 
 |   Property   |              Type              |              | Description                                                                                                                                                |
 | :----------: | :----------------------------: | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|   **type**   |            _string_            | **required** | The type of mutation to perform, must be one of `create`, `update`, `jsonPatch`\*, or `delete`.                                                            |
+|   **type**   |            _string_            | **required** | The type of mutation to perform, must be one of `create`, `update`, `json-patch`\*, or `delete`.                                                           |
 | **resource** |            _string_            | **required** | The path to the resource being requested, i.e. `indicators`.                                                                                               |
 |    **id**    | _string_ **or** _() => string_ |              | Required for `update` and `delete` mutations, not allowed for `create` mutations. Indicates that a particular **instance** of a collection will be mutated |
 | **partial**  |           _boolean_            |              | If performing an `update` mutation, set `partial: true` to replace only the provided fields of the target object.                                          |
@@ -17,7 +17,7 @@ A mutation defines a destructive operation performed on a collection or instance
 
 > See the [Mutation type definition](https://github.com/dhis2/app-runtime/blob/master/services/data/src/engine/types/Mutation.ts) for more information
 
-> \* When choosing the `jsonPatch` type, a PATCH request with content-type `application/json-patch+json` will be sent and the server will expect the "body" of the mutation to be a "patch document" (i.e. an array of operations). See [jsonpatch.com](http://jsonpatch.com) for a brief overview, or JSON Patch specifications in [RFC 6902](http://tools.ietf.org/html/rfc6902) for full details.
+> \* When choosing the `json-patch` type, a PATCH request with content-type `application/json-patch+json` will be sent and the server will expect the "body" of the mutation to be a "patch document" (i.e. an array of operations). See [jsonpatch.com](http://jsonpatch.com) for a brief overview, or JSON Patch specifications in [RFC 6902](http://tools.ietf.org/html/rfc6902) for full details.
 
 ## Examples
 

--- a/docs/types/Mutation.md
+++ b/docs/types/Mutation.md
@@ -8,7 +8,7 @@ A mutation defines a destructive operation performed on a collection or instance
 
 |   Property   |              Type              |              | Description                                                                                                                                                |
 | :----------: | :----------------------------: | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|   **type**   |            _string_            | **required** | The type of mutation to perform, must be one of `create`, `update`, or `delete`.                                                                           |
+|   **type**   |            _string_            | **required** | The type of mutation to perform, must be one of `create`, `update`, `jsonPatch`\*, or `delete`.                                                            |
 | **resource** |            _string_            | **required** | The path to the resource being requested, i.e. `indicators`.                                                                                               |
 |    **id**    | _string_ **or** _() => string_ |              | Required for `update` and `delete` mutations, not allowed for `create` mutations. Indicates that a particular **instance** of a collection will be mutated |
 | **partial**  |           _boolean_            |              | If performing an `update` mutation, set `partial: true` to replace only the provided fields of the target object.                                          |
@@ -16,6 +16,8 @@ A mutation defines a destructive operation performed on a collection or instance
 |   **data**   | _Object_ **or** _() => Object_ |              | The "body" of the mutation, the content of the newly created or updated resource. Disallowed for `delete` mutations                                        |
 
 > See the [Mutation type definition](https://github.com/dhis2/app-runtime/blob/master/services/data/src/engine/types/Mutation.ts) for more information
+
+> \* When choosing the `jsonPatch` type, a PATCH request with content-type `application/json-patch+json` will be sent and the server will expect the "body" of the mutation to be a "patch document" (i.e. an array of operations). See [jsonpatch.com](http://jsonpatch.com) for a brief overview, or JSON Patch specifications in [RFC 6902](http://tools.ietf.org/html/rfc6902) for full details.
 
 ## Examples
 

--- a/services/data/src/engine/helpers/getMutationFetchType.test.ts
+++ b/services/data/src/engine/helpers/getMutationFetchType.test.ts
@@ -8,6 +8,13 @@ describe('getMutationFetchType', () => {
         expect(
             getMutationFetchType({ type: 'delete', resource: 'test', id: 'id' })
         ).toBe('delete')
+        expect(
+            getMutationFetchType({
+                type: 'jsonPatch',
+                resource: 'test',
+                data: {},
+            })
+        ).toBe('jsonPatch')
     })
     it('should return `replace` for non-partial `update`', () => {
         expect(

--- a/services/data/src/engine/helpers/getMutationFetchType.test.ts
+++ b/services/data/src/engine/helpers/getMutationFetchType.test.ts
@@ -10,11 +10,11 @@ describe('getMutationFetchType', () => {
         ).toBe('delete')
         expect(
             getMutationFetchType({
-                type: 'jsonPatch',
+                type: 'json-patch',
                 resource: 'test',
                 data: {},
             })
-        ).toBe('jsonPatch')
+        ).toBe('json-patch')
     })
     it('should return `replace` for non-partial `update`', () => {
         expect(

--- a/services/data/src/engine/helpers/validate.test.ts
+++ b/services/data/src/engine/helpers/validate.test.ts
@@ -129,6 +129,19 @@ describe('query validation', () => {
             `)
         })
 
+        it('should fail if query is jsonPatch mutation with non-array data prop', () => {
+            const errors = getResourceQueryErrors('jsonPatch', {
+                resource: 'metadata',
+                data: {},
+            })
+            expect(errors).toHaveLength(1)
+            expect(errors).toMatchInlineSnapshot(`
+                Array [
+                  "Mutation type 'jsonPatch' requires property 'data' to be of type Array",
+                ]
+            `)
+        })
+
         it('should fail if unrecognized keys are passed to query', () => {
             const errors = getResourceQueryErrors('update', {
                 resource: 'indicators',

--- a/services/data/src/engine/helpers/validate.test.ts
+++ b/services/data/src/engine/helpers/validate.test.ts
@@ -129,15 +129,15 @@ describe('query validation', () => {
             `)
         })
 
-        it('should fail if query is jsonPatch mutation with non-array data prop', () => {
-            const errors = getResourceQueryErrors('jsonPatch', {
+        it('should fail if query is json-patch mutation with non-array data prop', () => {
+            const errors = getResourceQueryErrors('json-patch', {
                 resource: 'metadata',
                 data: {},
             })
             expect(errors).toHaveLength(1)
             expect(errors).toMatchInlineSnapshot(`
                 Array [
-                  "Mutation type 'jsonPatch' requires property 'data' to be of type Array",
+                  "Mutation type 'json-patch' requires property 'data' to be of type Array",
                 ]
             `)
         })

--- a/services/data/src/engine/helpers/validate.ts
+++ b/services/data/src/engine/helpers/validate.ts
@@ -42,6 +42,11 @@ export const getResourceQueryErrors = (
     if (type === 'delete' && query.data) {
         errors.push("Mutation type 'delete' does not support property 'data'")
     }
+    if (type === 'jsonPatch' && !Array.isArray(query.data)) {
+        errors.push(
+            "Mutation type 'jsonPatch' requires property 'data' to be of type Array"
+        )
+    }
     const invalidKeys = Object.keys(query).filter(
         k => !validQueryKeys.includes(k)
     )

--- a/services/data/src/engine/helpers/validate.ts
+++ b/services/data/src/engine/helpers/validate.ts
@@ -2,7 +2,14 @@ import { InvalidQueryError } from '../types/InvalidQueryError'
 import { ResolvedResourceQuery } from '../types/Query'
 
 const validQueryKeys = ['resource', 'id', 'params', 'data']
-const validTypes = ['read', 'create', 'update', 'replace', 'delete']
+const validTypes = [
+    'read',
+    'create',
+    'update',
+    'replace',
+    'delete',
+    'jsonPatch',
+]
 
 export const getResourceQueryErrors = (
     type: string,

--- a/services/data/src/engine/helpers/validate.ts
+++ b/services/data/src/engine/helpers/validate.ts
@@ -8,7 +8,7 @@ const validTypes = [
     'update',
     'replace',
     'delete',
-    'jsonPatch',
+    'json-patch',
 ]
 
 export const getResourceQueryErrors = (
@@ -42,9 +42,9 @@ export const getResourceQueryErrors = (
     if (type === 'delete' && query.data) {
         errors.push("Mutation type 'delete' does not support property 'data'")
     }
-    if (type === 'jsonPatch' && !Array.isArray(query.data)) {
+    if (type === 'json-patch' && !Array.isArray(query.data)) {
         errors.push(
-            "Mutation type 'jsonPatch' requires property 'data' to be of type Array"
+            "Mutation type 'json-patch' requires property 'data' to be of type Array"
         )
     }
     const invalidKeys = Object.keys(query).filter(

--- a/services/data/src/engine/types/ExecuteOptions.ts
+++ b/services/data/src/engine/types/ExecuteOptions.ts
@@ -1,7 +1,13 @@
 import { FetchError } from './FetchError'
 import { QueryVariables } from './Query'
 
-export type FetchType = 'create' | 'read' | 'update' | 'replace' | 'delete'
+export type FetchType =
+    | 'create'
+    | 'read'
+    | 'update'
+    | 'jsonPatch'
+    | 'replace'
+    | 'delete'
 export interface QueryExecuteOptions {
     variables?: QueryVariables
     signal?: AbortSignal

--- a/services/data/src/engine/types/ExecuteOptions.ts
+++ b/services/data/src/engine/types/ExecuteOptions.ts
@@ -5,7 +5,7 @@ export type FetchType =
     | 'create'
     | 'read'
     | 'update'
-    | 'jsonPatch'
+    | 'json-patch'
     | 'replace'
     | 'delete'
 export interface QueryExecuteOptions {

--- a/services/data/src/engine/types/Mutation.ts
+++ b/services/data/src/engine/types/Mutation.ts
@@ -4,7 +4,7 @@ import { ResourceQuery, QueryVariables } from './Query'
 export type MutationType =
     | 'create'
     | 'update'
-    | 'jsonPatch'
+    | 'json-patch'
     | 'replace'
     | 'delete'
 export interface MutationData {
@@ -18,7 +18,7 @@ export interface CreateMutation extends BaseMutation {
     data: MutationData
 }
 export interface UpdateMutation extends BaseMutation {
-    type: 'update' | 'replace' | 'jsonPatch'
+    type: 'update' | 'replace' | 'json-patch'
     id: string
     partial?: boolean
     data: MutationData

--- a/services/data/src/engine/types/Mutation.ts
+++ b/services/data/src/engine/types/Mutation.ts
@@ -1,7 +1,12 @@
 import { FetchError } from './FetchError'
 import { ResourceQuery, QueryVariables } from './Query'
 
-export type MutationType = 'create' | 'update' | 'replace' | 'delete'
+export type MutationType =
+    | 'create'
+    | 'update'
+    | 'jsonPatch'
+    | 'replace'
+    | 'delete'
 export interface MutationData {
     [key: string]: any
 }
@@ -13,7 +18,7 @@ export interface CreateMutation extends BaseMutation {
     data: MutationData
 }
 export interface UpdateMutation extends BaseMutation {
-    type: 'update' | 'replace'
+    type: 'update' | 'replace' | 'jsonPatch'
     id: string
     partial?: boolean
     data: MutationData

--- a/services/data/src/links/RestAPILink.ts
+++ b/services/data/src/links/RestAPILink.ts
@@ -37,12 +37,7 @@ export class RestAPILink implements DataEngineLink {
     ): Promise<JsonValue> {
         return this.fetch(
             queryToResourcePath(this.apiPath, query, type),
-            queryToRequestOptions({
-                type,
-                query,
-                apiVersion: this.apiVersion,
-                signal,
-            })
+            queryToRequestOptions(type, query, signal)
         )
     }
 }

--- a/services/data/src/links/RestAPILink.ts
+++ b/services/data/src/links/RestAPILink.ts
@@ -37,7 +37,12 @@ export class RestAPILink implements DataEngineLink {
     ): Promise<JsonValue> {
         return this.fetch(
             queryToResourcePath(this.apiPath, query, type),
-            queryToRequestOptions(type, query, signal)
+            queryToRequestOptions({
+                type,
+                query,
+                apiVersion: this.apiVersion,
+                signal,
+            })
         )
     }
 }

--- a/services/data/src/links/RestAPILink/queryToRequestOptions.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions.test.ts
@@ -54,10 +54,7 @@ describe('queryToRequestOptions', () => {
         })
         expect(options).toMatchInlineSnapshot(`
             Object {
-              "body": Object {
-                "answer": 42,
-                "foo": "bar",
-              },
+              "body": "{\\"answer\\":42,\\"foo\\":\\"bar\\"}",
               "headers": Object {
                 "Content-Type": "application/json-patch+json",
               },

--- a/services/data/src/links/RestAPILink/queryToRequestOptions.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions.test.ts
@@ -47,6 +47,26 @@ describe('queryToRequestOptions', () => {
         `)
     })
 
+    it('should return a valid Fetch option object for jsonPatch request', () => {
+        const options = queryToRequestOptions('jsonPatch', {
+            resource: 'test',
+            data: { answer: 42, foo: 'bar' },
+        })
+        expect(options).toMatchInlineSnapshot(`
+            Object {
+              "body": Object {
+                "answer": 42,
+                "foo": "bar",
+              },
+              "headers": Object {
+                "Content-Type": "application/json-patch+json",
+              },
+              "method": "PATCH",
+              "signal": undefined,
+            }
+        `)
+    })
+
     it('should return a valid Fetch option object for replace request', () => {
         const options = queryToRequestOptions('replace', {
             resource: 'test',

--- a/services/data/src/links/RestAPILink/queryToRequestOptions.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions.test.ts
@@ -47,8 +47,8 @@ describe('queryToRequestOptions', () => {
         `)
     })
 
-    it('should return a valid Fetch option object for jsonPatch request', () => {
-        const options = queryToRequestOptions('jsonPatch', {
+    it('should return a valid Fetch option object for json-patch request', () => {
+        const options = queryToRequestOptions('json-patch', {
             resource: 'test',
             data: { answer: 42, foo: 'bar' },
         })

--- a/services/data/src/links/RestAPILink/queryToRequestOptions.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions.ts
@@ -20,12 +20,20 @@ const getMethod = (type: FetchType): string => {
     }
 }
 
-export const queryToRequestOptions = (
-    type: FetchType,
-    query: ResolvedResourceQuery,
+type Options = {
+    type: FetchType
+    query: ResolvedResourceQuery
+    apiVersion: number
     signal?: AbortSignal
-): RequestInit => {
-    const contentType = requestContentType(type, query)
+}
+
+export const queryToRequestOptions = ({
+    type,
+    query,
+    apiVersion,
+    signal,
+}: Options): RequestInit => {
+    const contentType = requestContentType(type, query, apiVersion)
 
     return {
         method: getMethod(type),

--- a/services/data/src/links/RestAPILink/queryToRequestOptions.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions.ts
@@ -12,7 +12,7 @@ const getMethod = (type: FetchType): string => {
         case 'read':
             return 'GET'
         case 'update':
-        case 'jsonPatch':
+        case 'json-patch':
             return 'PATCH'
         case 'replace':
             return 'PUT'

--- a/services/data/src/links/RestAPILink/queryToRequestOptions.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions.ts
@@ -12,28 +12,23 @@ const getMethod = (type: FetchType): string => {
         case 'read':
             return 'GET'
         case 'update':
+        case 'jsonPatch':
             return 'PATCH'
         case 'replace':
             return 'PUT'
         case 'delete':
             return 'DELETE'
+        default:
+            return ''
     }
 }
 
-type Options = {
-    type: FetchType
-    query: ResolvedResourceQuery
-    apiVersion: number
+export const queryToRequestOptions = (
+    type: FetchType,
+    query: ResolvedResourceQuery,
     signal?: AbortSignal
-}
-
-export const queryToRequestOptions = ({
-    type,
-    query,
-    apiVersion,
-    signal,
-}: Options): RequestInit => {
-    const contentType = requestContentType(type, query, apiVersion)
+): RequestInit => {
+    const contentType = requestContentType(type, query)
 
     return {
         method: getMethod(type),

--- a/services/data/src/links/RestAPILink/queryToRequestOptions.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions.ts
@@ -19,7 +19,7 @@ const getMethod = (type: FetchType): string => {
         case 'delete':
             return 'DELETE'
         default:
-            return ''
+            throw new Error(`Unknown type ${type}`)
     }
 }
 

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.test.ts
@@ -11,6 +11,11 @@ describe('requestContentType', () => {
             requestContentType('create', { resource: 'test', data: 'test' })
         ).toEqual('application/json')
     })
+    it('returns "application/json-patch+json" when the fetch type is "jsonPatch"', () => {
+        expect(
+            requestContentType('jsonPatch', { resource: 'test', data: 'test' })
+        ).toEqual('application/json-patch+json')
+    })
     it('returns "multipart/form-data" for a specific resource that expects it', () => {
         expect(
             requestContentType('create', {

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.test.ts
@@ -11,9 +11,9 @@ describe('requestContentType', () => {
             requestContentType('create', { resource: 'test', data: 'test' })
         ).toEqual('application/json')
     })
-    it('returns "application/json-patch+json" when the fetch type is "jsonPatch"', () => {
+    it('returns "application/json-patch+json" when the fetch type is "json-patch"', () => {
         expect(
-            requestContentType('jsonPatch', { resource: 'test', data: 'test' })
+            requestContentType('json-patch', { resource: 'test', data: 'test' })
         ).toEqual('application/json-patch+json')
     })
     it('returns "multipart/form-data" for a specific resource that expects it', () => {

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.ts
@@ -89,7 +89,10 @@ export const requestBodyForContentType = (
         return undefined
     }
 
-    if (contentType === 'application/json') {
+    if (
+        contentType === 'application/json' ||
+        contentType === 'application/json-patch+json'
+    ) {
         return JSON.stringify(data)
     }
 

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.ts
@@ -9,9 +9,6 @@ type RequestContentType =
     | 'multipart/form-data'
     | null
 
-const isJsonPatchMutation = (type: FetchType, apiVersion: number) =>
-    type === 'update' && apiVersion >= 37
-
 const resourceExpectsTextPlain = (
     type: FetchType,
     query: ResolvedResourceQuery
@@ -46,14 +43,13 @@ const convertToFormData = (data: Record<string, any>): FormData => {
 
 export const requestContentType = (
     type: FetchType,
-    query: ResolvedResourceQuery,
-    apiVersion: number
+    query: ResolvedResourceQuery
 ): null | RequestContentType => {
     if (!query.data) {
         return null
     }
 
-    if (isJsonPatchMutation(type, apiVersion)) {
+    if (type === 'jsonPatch') {
         return 'application/json-patch+json'
     }
 

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/requestContentType.ts
@@ -49,7 +49,7 @@ export const requestContentType = (
         return null
     }
 
-    if (type === 'jsonPatch') {
+    if (type === 'json-patch') {
         return 'application/json-patch+json'
     }
 


### PR DESCRIPTION
This introduces JSON Patch support for the `useDataMutation` hook, via an explicit type. The `data` property needs to be a valid patch array. It is entirely up to the user to ensure this patch is valid, we do no form of validation in app-runtime.

A JSON Patch mutation object would as follows:
```js
const updateMutation = {
    type: 'jsonPatch',  // The new type
    resource: 'userGroups',
    id: 'xyz123',
    data: [ // patch array
        { op: 'replace', path: '/baz', value: 'boo' },
        { op: 'add', path: '/hello', value: ['world'] },
        { op: 'remove', path: '/foo' },
    ],
}
```