### PR TITLE
fix(offline-interface): improve sw update message API

### DIFF
--- a/examples/cra/yarn.lock
+++ b/examples/cra/yarn.lock
@@ -1054,26 +1054,26 @@
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@dhis2/app-runtime@file:../../runtime":
-  version "3.0.0"
+  version "3.2.0"
   dependencies:
-    "@dhis2/app-service-alerts" "3.0.0"
-    "@dhis2/app-service-config" "3.0.0"
-    "@dhis2/app-service-data" "3.0.0"
-    "@dhis2/app-service-offline" "3.0.0"
+    "@dhis2/app-service-alerts" "3.2.0"
+    "@dhis2/app-service-config" "3.2.0"
+    "@dhis2/app-service-data" "3.2.0"
+    "@dhis2/app-service-offline" "3.2.0"
 
-"@dhis2/app-service-alerts@3.0.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.0.0"
+"@dhis2/app-service-alerts@3.2.0", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.2.0"
 
-"@dhis2/app-service-config@3.0.0", "@dhis2/app-service-config@file:../../services/config":
-  version "3.0.0"
+"@dhis2/app-service-config@3.2.0", "@dhis2/app-service-config@file:../../services/config":
+  version "3.2.0"
 
-"@dhis2/app-service-data@3.0.0", "@dhis2/app-service-data@file:../../services/data":
-  version "3.0.0"
+"@dhis2/app-service-data@3.2.0", "@dhis2/app-service-data@file:../../services/data":
+  version "3.2.0"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.0.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.0.0"
+"@dhis2/app-service-offline@3.2.0", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.2.0"
   dependencies:
     lodash "^4.17.21"
 

--- a/examples/query-playground/yarn.lock
+++ b/examples/query-playground/yarn.lock
@@ -1790,26 +1790,26 @@
     moment "^2.24.0"
 
 "@dhis2/app-runtime@*", "@dhis2/app-runtime@^2.2.2", "@dhis2/app-runtime@file:../../runtime":
-  version "3.0.0"
+  version "3.2.0"
   dependencies:
-    "@dhis2/app-service-alerts" "3.0.0"
-    "@dhis2/app-service-config" "3.0.0"
-    "@dhis2/app-service-data" "3.0.0"
-    "@dhis2/app-service-offline" "3.0.0"
+    "@dhis2/app-service-alerts" "3.2.0"
+    "@dhis2/app-service-config" "3.2.0"
+    "@dhis2/app-service-data" "3.2.0"
+    "@dhis2/app-service-offline" "3.2.0"
 
-"@dhis2/app-service-alerts@3.0.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.0.0"
+"@dhis2/app-service-alerts@3.2.0", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.2.0"
 
-"@dhis2/app-service-config@3.0.0", "@dhis2/app-service-config@file:../../services/config":
-  version "3.0.0"
+"@dhis2/app-service-config@3.2.0", "@dhis2/app-service-config@file:../../services/config":
+  version "3.2.0"
 
-"@dhis2/app-service-data@3.0.0", "@dhis2/app-service-data@file:../../services/data":
-  version "3.0.0"
+"@dhis2/app-service-data@3.2.0", "@dhis2/app-service-data@file:../../services/data":
+  version "3.2.0"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.0.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.0.0"
+"@dhis2/app-service-offline@3.2.0", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.2.0"
   dependencies:
     lodash "^4.17.21"
 

--- a/services/offline/src/lib/offline-interface.tsx
+++ b/services/offline/src/lib/offline-interface.tsx
@@ -21,6 +21,16 @@ interface OfflineInterfaceProviderInput {
     children: React.ReactNode
 }
 
+interface AlertAction {
+    label: string
+    onClick: () => void
+}
+
+interface PromptUpdateAlertOptions {
+    message: string
+    actions: AlertAction[]
+}
+
 /**
  * Receives an OfflineInterface instance as a prop (presumably from the app
  * adapter) and provides it as context for other offline tools.
@@ -34,9 +44,9 @@ export function OfflineInterfaceProvider({
     children,
 }: OfflineInterfaceProviderInput): JSX.Element {
     const { show } = useAlert(
-        ({ message }) => message,
-        ({ action, onConfirm }) => ({
-            actions: [{ label: action, onClick: onConfirm }],
+        ({ message }: PromptUpdateAlertOptions) => message,
+        ({ actions }: PromptUpdateAlertOptions) => ({
+            actions,
             permanent: true,
         })
     )


### PR DESCRIPTION
Relates to this app-platform [slack thread](https://dhis2.slack.com/archives/CLJSVA1RV/p1632485940049900):
Updates the 'prompt message' API so more actions can be provided to the 'Update SW' alert; the message and actions will be changed in the app platform here: https://github.com/dhis2/app-platform/pull/664
https://jira.dhis2.org/browse/LIBS-231

Both this one and the app-platform change will be back-ported to 2.37-safe branches