### PR TITLE
fix(clear-caches): allow caches.keys to fail (2.x)

### DIFF
--- a/services/offline/src/lib/__tests__/clear-sensitive-caches.test.ts
+++ b/services/offline/src/lib/__tests__/clear-sensitive-caches.test.ts
@@ -48,6 +48,20 @@ it('does not fail if there are no caches or no sections-db', () => {
     return expect(clearSensitiveCaches()).resolves.toBe(false)
 })
 
+it('returns false if caches.keys throws', async () => {
+    const spy = jest.fn(() => {
+        throw new Error('Security Error')
+    })
+    window.caches = {
+        keys: spy,
+    }
+
+    const result = await clearSensitiveCaches()
+
+    expect(spy).toHaveBeenCalled()
+    expect(result).toBe(false)
+})
+
 it('clears potentially sensitive caches', async () => {
     const testKeys = ['cache1', 'cache2', 'app-shell']
     const keysMock = jest

--- a/services/offline/src/lib/clear-sensitive-caches.ts
+++ b/services/offline/src/lib/clear-sensitive-caches.ts
@@ -63,8 +63,17 @@ export async function clearSensitiveCaches(
     dbName: string = SECTIONS_DB
 ): Promise<any> {
     console.debug('Clearing sensitive caches')
+    let cacheKeys
 
-    const cacheKeys = await caches.keys()
+    // caches.keys can fail in insecure contexts, see:
+    // https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage
+    try {
+        cacheKeys = await caches.keys()
+    } catch (e) {
+        // Return false since no caches have been cleared
+        return false
+    }
+
     return Promise.all([
         // (Resolves to 'false' because this can't detect if anything was deleted):
         clearDB(dbName).then(() => false),


### PR DESCRIPTION
Back-port of #1027 