### PR TITLE
feat(alerts-service): add showFetchAlert hook

### DIFF
--- a/services/alerts/src/__tests__/useFetchAlert.test.tsx
+++ b/services/alerts/src/__tests__/useFetchAlert.test.tsx
@@ -1,0 +1,19 @@
+import { renderHook } from '@testing-library/react-hooks'
+import React, { ReactNode } from 'react'
+import { AlertsProvider, useFetchAlert } from '../index'
+
+describe('useFetchAlert', () => {
+    it('Hook returns a showSuccess, showError and hide function', () => {
+        const wrapper = ({ children }: { children?: ReactNode }) => (
+            <AlertsProvider>{children}</AlertsProvider>
+        )
+        const { result } = renderHook(() => useFetchAlert(), { wrapper })
+
+        expect(result.current).toHaveProperty('showSuccess')
+        expect(typeof result.current.showSuccess).toBe('function')
+        expect(result.current).toHaveProperty('showError')
+        expect(typeof result.current.showError).toBe('function')
+        expect(result.current).toHaveProperty('hide')
+        expect(typeof result.current.hide).toBe('function')
+    })
+})

--- a/services/alerts/src/index.ts
+++ b/services/alerts/src/index.ts
@@ -1,3 +1,4 @@
 export { AlertsProvider } from './AlertsProvider'
 export { useAlerts } from './useAlerts'
 export { useAlert } from './useAlert'
+export { useFetchAlert } from './useFetchAlert'

--- a/services/alerts/src/useFetchAlert.ts
+++ b/services/alerts/src/useFetchAlert.ts
@@ -1,0 +1,19 @@
+import { useAlert } from './useAlert'
+
+const useFetchAlert = (): {
+    showSuccess: (message: string) => void
+    showError: (message: string) => void
+    hide: () => void
+} => {
+    const { show, hide } = useAlert(
+        ({ message }) => message,
+        ({ isError }) => (isError ? { critical: true } : { success: true })
+    )
+    return {
+        showSuccess: (message: string) => show({ message }),
+        showError: (message: string) => show({ message, isError: true }),
+        hide: hide,
+    }
+}
+
+export { useFetchAlert }


### PR DESCRIPTION
This could be a convenient hook to add. I haven't spent a lot of time on this because I don't know if we would want to add this hook in the first place. If we do, I would have to update the docs before we merge.