### PR TITLE
fix(use-data-query): improve stability of refetch function identity

### DIFF
--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -426,6 +426,42 @@ describe('useDataQuery', () => {
     })
 
     describe('return values: refetch', () => {
+        it('Should have a stable identity if the variables have not changed', async () => {
+            const data = {
+                answer: () => 42,
+            }
+            const query = { x: { resource: 'answer' } }
+            const wrapper = ({ children }) => (
+                <CustomDataProvider data={data}>{children}</CustomDataProvider>
+            )
+
+            const { result, waitForNextUpdate, rerender } = renderHook(
+                () => useDataQuery(query),
+                {
+                    wrapper,
+                }
+            )
+
+            const firstRefetch = result.current.refetch
+
+            await waitForNextUpdate()
+
+            act(() => {
+                result.current.refetch()
+
+                /**
+                 * FIXME: https://github.com/tannerlinsley/react-query/issues/2481
+                 * This forced rerender is not necessary in the app, just when testing.
+                 * It is unclear why.
+                 */
+                rerender()
+            })
+
+            await waitForNextUpdate()
+
+            expect(result.current.refetch).toBe(firstRefetch)
+        })
+
         it('Should return stale data and set loading to true on refetch', async () => {
             const answers = [42, 43]
             const mockSpy = jest.fn(() => Promise.resolve(answers.shift()))

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useCallback } from 'react'
 import { useQuery, setLogger } from 'react-query'
 import { Query, QueryOptions } from '../../engine'
 import { FetchError } from '../../engine/types/FetchError'
@@ -89,52 +89,59 @@ export const useDataQuery = (
     /**
      * Refetch allows a user to update the variables or just
      * trigger a refetch of the query with the current variables.
+     *
+     * We're using useCallback to make the identity of the function
+     * as stable as possible, so that it won't trigger excessive
+     * rerenders when used for side-effects.
      */
 
-    const refetch: QueryRefetchFunction = newVariables => {
-        /**
-         * If there are no updates that will trigger an automatic refetch
-         * we'll need to call react-query's refetch directly
-         */
-        if (enabled && !newVariables) {
-            return queryRefetch({
-                cancelRefetch: true,
-                throwOnError: false,
-            }).then(({ data }) => data)
-        }
-
-        if (!enabled) {
-            setEnabled(true)
-        }
-
-        if (newVariables) {
-            // Use cached hash if it exists
-            const currentHash =
-                variablesHash.current || stableVariablesHash(variables)
-
-            const mergedVariables = { ...variables, ...newVariables }
-            const mergedHash = stableVariablesHash(mergedVariables)
-            const identical = currentHash === mergedHash
-
-            if (identical) {
-                // If the variables are identical we'll need to trigger the refetch manually
+    const refetch: QueryRefetchFunction = useCallback(
+        newVariables => {
+            /**
+             * If there are no updates that will trigger an automatic refetch
+             * we'll need to call react-query's refetch directly
+             */
+            if (enabled && !newVariables) {
                 return queryRefetch({
                     cancelRefetch: true,
                     throwOnError: false,
                 }).then(({ data }) => data)
-            } else {
-                variablesHash.current = mergedHash
-                setVariables(mergedVariables)
             }
-        }
 
-        // This promise does not currently reject on errors
-        return new Promise(resolve => {
-            refetchCallback.current = data => {
-                resolve(data)
+            if (!enabled) {
+                setEnabled(true)
             }
-        })
-    }
+
+            if (newVariables) {
+                // Use cached hash if it exists
+                const currentHash =
+                    variablesHash.current || stableVariablesHash(variables)
+
+                const mergedVariables = { ...variables, ...newVariables }
+                const mergedHash = stableVariablesHash(mergedVariables)
+                const identical = currentHash === mergedHash
+
+                if (identical) {
+                    // If the variables are identical we'll need to trigger the refetch manually
+                    return queryRefetch({
+                        cancelRefetch: true,
+                        throwOnError: false,
+                    }).then(({ data }) => data)
+                } else {
+                    variablesHash.current = mergedHash
+                    setVariables(mergedVariables)
+                }
+            }
+
+            // This promise does not currently reject on errors
+            return new Promise(resolve => {
+                refetchCallback.current = data => {
+                    resolve(data)
+                }
+            })
+        },
+        [enabled, queryRefetch, variables]
+    )
 
     /**
      * react-query returns null or an error, but we return undefined


### PR DESCRIPTION
The refetch function was recreated on each render, which caused problems when it was used with refetch. If refetch was included in the useEffect dependency array the effect would run every render. By using useCallback the identity of refetch will be more stable and allow for it to be included in the dependency array again, which is recommended practice.

The identity of the refetch function will only change if you've changed the variables or changed the value of `lazy`, which seems appropriate to me. Eventually we could make it completely stable by not forking props to state, but that's a bigger change.