### PR TITLE
fix(data-service): identify interpretation update requests correctly

### DIFF
--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
@@ -1,7 +1,8 @@
 import {
     isReplyToMessageConversation,
     isCreateFeedbackMessage,
-    isCreateOrUpdateInterpretation,
+    isCreateInterpretation,
+    isUpdateInterpretation,
     isCommentOnInterpretation,
     isInterpretationCommentUpdate,
     isAddOrUpdateSystemOrUserSetting,
@@ -43,39 +44,78 @@ describe('isCreateFeedbackMessage', () => {
     })
 })
 
-describe('isCreateOrUpdateInterpretation', () => {
+describe('isCreateInterpretation', () => {
     it('returns true for a POST to "interpretations/chart/${id}"', () => {
         expect(
-            isCreateOrUpdateInterpretation('create', {
+            isCreateInterpretation('create', {
                 resource: 'interpretations/chart/oXD88WWSQpR',
             })
         ).toEqual(true)
     })
-    it('returns true for a PUT to "interpretations/chart/${id}"', () => {
+    it('returns false for a PUT to "interpretations/chart/${id}"', () => {
         expect(
-            isCreateOrUpdateInterpretation('replace', {
+            isCreateInterpretation('replace', {
                 resource: 'interpretations/chart/oXD88WWSQpR',
             })
-        ).toEqual(true)
-    })
-    it('returns true for PUT with populated query.id', () => {
-        expect(
-            isCreateOrUpdateInterpretation('replace', {
-                resource: 'interpretations/chart',
-                id: 'oXD88WWSQpR',
-            })
-        ).toEqual(true)
+        ).toEqual(false)
     })
     it('retuns false for PATCH requests with a valid query', () => {
         expect(
-            isCreateOrUpdateInterpretation('update', {
+            isCreateInterpretation('update', {
                 resource: 'interpretations/chart/oXD88WWSQpR',
             })
         ).toEqual(false)
     })
     it('returns false for a request to a different resource', () => {
         expect(
-            isCreateOrUpdateInterpretation('create', {
+            isCreateInterpretation('create', {
+                resource: 'interpretations/dummy/oXD88WWSQpR',
+            })
+        ).toEqual(false)
+    })
+})
+
+describe('isUpdateInterpretation', () => {
+    it('returns true for a PUT to "interpretations/${id}"', () => {
+        expect(
+            isUpdateInterpretation('replace', {
+                resource: 'interpretations/oXD88WWSQpR',
+            })
+        ).toEqual(true)
+    })
+    it('returns true for PUT with populated query.id', () => {
+        expect(
+            isUpdateInterpretation('replace', {
+                resource: 'interpretations',
+                id: 'oXD88WWSQpR',
+            })
+        ).toEqual(true)
+    })
+    it('returns false for a POST to "interpretations/${id}"', () => {
+        expect(
+            isUpdateInterpretation('create', {
+                resource: 'interpretations/oXD88WWSQpR',
+            })
+        ).toEqual(false)
+    })
+    it('returns false for a PATCH to "interpretations/${id}"', () => {
+        expect(
+            isUpdateInterpretation('update', {
+                resource: 'interpretations/oXD88WWSQpR',
+            })
+        ).toEqual(false)
+    })
+    it('returns false for PATCH with populated query.id', () => {
+        expect(
+            isUpdateInterpretation('update', {
+                resource: 'interpretations',
+                id: 'oXD88WWSQpR',
+            })
+        ).toEqual(false)
+    })
+    it('returns false for a request to a different resource', () => {
+        expect(
+            isUpdateInterpretation('create', {
                 resource: 'interpretations/dummy/oXD88WWSQpR',
             })
         ).toEqual(false)

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
@@ -15,7 +15,7 @@ import { ResolvedResourceQuery, FetchType } from '../../../engine'
 export const isReplyToMessageConversation = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
-) => {
+): boolean => {
     const pattern = /^messageConversations\/[a-zA-Z0-9]{11}$/
     return type === 'create' && pattern.test(resource)
 }
@@ -24,26 +24,35 @@ export const isReplyToMessageConversation = (
 export const isCreateFeedbackMessage = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
-) => type === 'create' && resource === 'messageConversations/feedback'
+): boolean => type === 'create' && resource === 'messageConversations/feedback'
 
-// POST or PUT to `interpretations/${objectType}/${id}` (add or update an interpretation)
-export const isCreateOrUpdateInterpretation = (
+// POST `interpretations/${objectType}/${id}` (add an interpretation to a visualization)
+export const isCreateInterpretation = (
+    type: FetchType,
+    { resource }: ResolvedResourceQuery
+): boolean => {
+    const pattern = /^interpretations\/(?:reportTable|chart|visualization|map|eventReport|eventChart|dataSetReport)\/[a-zA-Z0-9]{11}$/
+    return type === 'create' && pattern.test(resource)
+}
+
+// PUT to `interpretations/${id}` (update an interpretation)
+export const isUpdateInterpretation = (
     type: FetchType,
     { resource, id }: ResolvedResourceQuery
-) => {
-    if (type !== 'create' && type !== 'replace') {
+): boolean => {
+    if (type !== 'replace') {
         return false
     }
 
     let resourcePattern
-    if (type === 'replace' && id) {
-        resourcePattern = /^interpretations\/(?:reportTable|chart|visualization|map|eventReport|eventChart|dataSetReport)$/
+    if (id) {
+        resourcePattern = /^interpretations$/
         const idPattern = /^[a-zA-Z0-9]{11}$/
 
         return resourcePattern.test(resource) && idPattern.test(id)
     }
 
-    resourcePattern = /^interpretations\/(?:reportTable|chart|visualization|map|eventReport|eventChart|dataSetReport)\/[a-zA-Z0-9]{11}$/
+    resourcePattern = /^interpretations\/[a-zA-Z0-9]{11}$/
 
     return resourcePattern.test(resource)
 }
@@ -52,7 +61,7 @@ export const isCreateOrUpdateInterpretation = (
 export const isCommentOnInterpretation = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
-) => {
+): boolean => {
     const pattern = /^interpretations\/[a-zA-Z0-9]{11}\/comments$/
     return type === 'create' && pattern.test(resource)
 }
@@ -62,7 +71,7 @@ export const isCommentOnInterpretation = (
 export const isInterpretationCommentUpdate = (
     type: FetchType,
     { resource, id }: ResolvedResourceQuery
-) => {
+): boolean => {
     if (type !== 'replace') {
         return false
     }
@@ -87,7 +96,7 @@ export const isInterpretationCommentUpdate = (
 export const isAddOrUpdateSystemOrUserSetting = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
-) => {
+): boolean => {
     // At least 4 chars because the all start with 'key' (i.e. keyStyle)
     const pattern = /^(?:systemSettings|userSettings)\/[a-zA-Z]{4,}$/
     return type === 'create' && pattern.test(resource)
@@ -98,7 +107,7 @@ export const isAddOrUpdateSystemOrUserSetting = (
 export const addOrUpdateConfigurationProperty = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
-) => {
+): boolean => {
     // NOTE: The corsWhitelist property does expect "application/json"
     const pattern = /^(configuration)\/([a-zA-Z]{1,50})$/
     const match = resource.match(pattern)
@@ -109,4 +118,4 @@ export const addOrUpdateConfigurationProperty = (
 export const isMetadataPackageInstallation = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
-) => type === 'create' && resource === 'synchronization/metadataPull'
+): boolean => type === 'create' && resource === 'synchronization/metadataPull'


### PR DESCRIPTION
The `@dhis2/app-service-data` package does some automatic content-type conversion. There are some text/plain matchers in place which ensure the content-type is set accordingly for specific resources. There was an error in the matcher for adding/updating an interpretation, we were treating `POST` and `PUT` requests the same, but [the docs clearly state](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/visualizations.html#webapi_interpretations) they are different: 
- Creating an interpretation should be done with a `POST` to `/api/interpretations/{object-type}/{object-id}` (where `object-id` actually refers to the visualisation)
- Updating an interpretation should be done with a `PUT` to `/api/interpretations/{id}` (where `id` actually refers to the interpretation)

This PR corrects this.

One thing that slightly worries me is the fact that this bug has been undetected for about a year. It could be I am the first one trying to update interpretations using the data-engine?