### PR TITLE
feat: view layer server version toggling

### DIFF
--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -6,6 +6,7 @@
         "@dhis2/app-runtime": "file:../../runtime",
         "@dhis2/app-service-config": "file:../../services/config",
         "@dhis2/app-service-data": "file:../../services/data",
+        "@dhis2/app-service-feature-toggling": "file:../../services/feature-toggling",
         "prop-types": "^15.7.2",
         "react": "~16.8.6",
         "react-dom": "~16.8.6",
@@ -16,7 +17,8 @@
         "@dhis2/app-service-alerts": "file:../../services/alerts",
         "@dhis2/app-service-config": "file:../../services/config",
         "@dhis2/app-service-data": "file:../../services/data",
-        "@dhis2/app-service-offline": "file:../../services/offline"
+        "@dhis2/app-service-offline": "file:../../services/offline",
+        "@dhis2/app-service-feature-toggling": "file:../../services/feature-toggling"
     },
     "scripts": {
         "start": "react-scripts start",

--- a/examples/cra/src/App.js
+++ b/examples/cra/src/App.js
@@ -4,6 +4,7 @@ import { Alerts } from './components/Alerts'
 import { ConfigConsumer } from './components/ConfigConsumer'
 import { IndicatorList } from './components/IndicatorList'
 import { OnlineStatus } from './components/OnlineStatus'
+import { ServerVersionToggle } from './components/ServerVersionToggle'
 import { SwitchableProvider } from './components/SwitchableProvider'
 
 const config = {
@@ -24,6 +25,7 @@ const App = () => {
                     <ConfigConsumer />
                     <IndicatorList />
                     <Alerts />
+                    <ServerVersionToggle />
                 </header>
             </div>
         </SwitchableProvider>

--- a/examples/cra/src/components/ServerVersionToggle.js
+++ b/examples/cra/src/components/ServerVersionToggle.js
@@ -1,0 +1,41 @@
+import {
+    ServerVersionSwitch,
+    ServerVersionCase,
+    useDataQuery,
+} from '@dhis2/app-runtime'
+import { ConfigProvider, useConfig } from '@dhis2/app-service-config'
+import React from 'react'
+
+const systemInfoQuery = {
+    sysinfo: {
+        resource: 'system/info',
+    },
+}
+export const ServerVersionToggle = () => {
+    const parentConfig = useConfig()
+    const { loading, data } = useDataQuery(systemInfoQuery, {
+        onComplete: console.log,
+        onError: console.error,
+    }) // Only necessary because this isn't a platform application
+    return (
+        <ConfigProvider config={{ ...parentConfig, systemInfo: data?.sysinfo }}>
+            <span>Server version:</span>
+            {loading && '...'}
+            {data && (
+                <ServerVersionSwitch>
+                    <ServerVersionCase max="2.34">&lt;= 34</ServerVersionCase>
+                    <ServerVersionCase min="2.35" max="2.35">
+                        35
+                    </ServerVersionCase>
+                    <ServerVersionCase min="2.36" max="2.36">
+                        36
+                    </ServerVersionCase>
+                    <ServerVersionCase min="2.37" max="2.37">
+                        37
+                    </ServerVersionCase>
+                    <ServerVersionCase min="2.38">&gt;= 38</ServerVersionCase>
+                </ServerVersionSwitch>
+            )}
+        </ConfigProvider>
+    )
+}

--- a/examples/cra/src/components/ServerVersionToggle.js
+++ b/examples/cra/src/components/ServerVersionToggle.js
@@ -13,10 +13,7 @@ const systemInfoQuery = {
 }
 export const ServerVersionToggle = () => {
     const parentConfig = useConfig()
-    const { loading, data } = useDataQuery(systemInfoQuery, {
-        onComplete: console.log,
-        onError: console.error,
-    }) // Only necessary because this isn't a platform application
+    const { loading, data } = useDataQuery(systemInfoQuery) // Only necessary because this isn't a platform application
     return (
         <ConfigProvider config={{ ...parentConfig, systemInfo: data?.sysinfo }}>
             <span>Server version:</span>

--- a/examples/cra/yarn.lock
+++ b/examples/cra/yarn.lock
@@ -1054,26 +1054,30 @@
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@dhis2/app-runtime@file:../../runtime":
-  version "3.2.0"
+  version "3.2.6"
   dependencies:
-    "@dhis2/app-service-alerts" "3.2.0"
-    "@dhis2/app-service-config" "3.2.0"
-    "@dhis2/app-service-data" "3.2.0"
-    "@dhis2/app-service-offline" "3.2.0"
+    "@dhis2/app-service-alerts" "3.2.6"
+    "@dhis2/app-service-config" "3.2.6"
+    "@dhis2/app-service-data" "3.2.6"
+    "@dhis2/app-service-feature-toggling" "3.2.6"
+    "@dhis2/app-service-offline" "3.2.6"
 
-"@dhis2/app-service-alerts@3.2.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.2.0"
+"@dhis2/app-service-alerts@3.2.6", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.2.6"
 
-"@dhis2/app-service-config@3.2.0", "@dhis2/app-service-config@file:../../services/config":
-  version "3.2.0"
+"@dhis2/app-service-config@3.2.6", "@dhis2/app-service-config@file:../../services/config":
+  version "3.2.6"
 
-"@dhis2/app-service-data@3.2.0", "@dhis2/app-service-data@file:../../services/data":
-  version "3.2.0"
+"@dhis2/app-service-data@3.2.6", "@dhis2/app-service-data@file:../../services/data":
+  version "3.2.6"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.2.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.2.0"
+"@dhis2/app-service-feature-toggling@3.2.6", "@dhis2/app-service-feature-toggling@file:../../services/feature-toggling":
+  version "3.2.6"
+
+"@dhis2/app-service-offline@3.2.6", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.2.6"
   dependencies:
     lodash "^4.17.21"
 

--- a/examples/query-playground/package.json
+++ b/examples/query-playground/package.json
@@ -29,6 +29,7 @@
         "@dhis2/app-service-alerts": "file:../../services/alerts",
         "@dhis2/app-service-config": "file:../../services/config",
         "@dhis2/app-service-data": "file:../../services/data",
-        "@dhis2/app-service-offline": "file:../../services/offline"
+        "@dhis2/app-service-offline": "file:../../services/offline",
+        "@dhis2/app-service-feature-toggling": "file:../../services/feature-toggling"
     }
 }

--- a/examples/query-playground/yarn.lock
+++ b/examples/query-playground/yarn.lock
@@ -1790,26 +1790,30 @@
     moment "^2.24.0"
 
 "@dhis2/app-runtime@*", "@dhis2/app-runtime@^2.2.2", "@dhis2/app-runtime@file:../../runtime":
-  version "3.2.0"
+  version "3.2.6"
   dependencies:
-    "@dhis2/app-service-alerts" "3.2.0"
-    "@dhis2/app-service-config" "3.2.0"
-    "@dhis2/app-service-data" "3.2.0"
-    "@dhis2/app-service-offline" "3.2.0"
+    "@dhis2/app-service-alerts" "3.2.6"
+    "@dhis2/app-service-config" "3.2.6"
+    "@dhis2/app-service-data" "3.2.6"
+    "@dhis2/app-service-feature-toggling" "3.2.6"
+    "@dhis2/app-service-offline" "3.2.6"
 
-"@dhis2/app-service-alerts@3.2.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.2.0"
+"@dhis2/app-service-alerts@3.2.6", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.2.6"
 
-"@dhis2/app-service-config@3.2.0", "@dhis2/app-service-config@file:../../services/config":
-  version "3.2.0"
+"@dhis2/app-service-config@3.2.6", "@dhis2/app-service-config@file:../../services/config":
+  version "3.2.6"
 
-"@dhis2/app-service-data@3.2.0", "@dhis2/app-service-data@file:../../services/data":
-  version "3.2.0"
+"@dhis2/app-service-data@3.2.6", "@dhis2/app-service-data@file:../../services/data":
+  version "3.2.6"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.2.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.2.0"
+"@dhis2/app-service-feature-toggling@3.2.6", "@dhis2/app-service-feature-toggling@file:../../services/feature-toggling":
+  version "3.2.6"
+
+"@dhis2/app-service-offline@3.2.6", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.2.6"
   dependencies:
     lodash "^4.17.21"
 

--- a/runtime/src/Provider.tsx
+++ b/runtime/src/Provider.tsx
@@ -2,6 +2,7 @@ import { AlertsProvider } from '@dhis2/app-service-alerts'
 import { ConfigProvider } from '@dhis2/app-service-config'
 import { Config } from '@dhis2/app-service-config/build/types/types'
 import { DataProvider } from '@dhis2/app-service-data'
+import { ServerVersionRangeProvider } from '@dhis2/app-service-feature-toggling'
 import { OfflineProvider } from '@dhis2/app-service-offline'
 import React from 'react'
 
@@ -16,13 +17,17 @@ export const Provider = ({
     offlineInterface,
 }: ProviderInput) => (
     <ConfigProvider config={config}>
-        <AlertsProvider>
-            <DataProvider>
-                <OfflineProvider offlineInterface={offlineInterface}>
-                    {children}
-                </OfflineProvider>
-            </DataProvider>
-        </AlertsProvider>
+        <ServerVersionRangeProvider
+            range={{ min: config.minDHIS2Version, max: config.maxDHIS2Version }}
+        >
+            <AlertsProvider>
+                <DataProvider>
+                    <OfflineProvider offlineInterface={offlineInterface}>
+                        {children}
+                    </OfflineProvider>
+                </DataProvider>
+            </AlertsProvider>
+        </ServerVersionRangeProvider>
     </ConfigProvider>
 )
 

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -20,4 +20,9 @@ export {
     clearSensitiveCaches,
 } from '@dhis2/app-service-offline'
 
+export {
+    ServerVersionSwitch,
+    ServerVersionCase,
+} from '@dhis2/app-service-feature-toggling'
+
 export { Provider } from './Provider'

--- a/services/config/src/types.ts
+++ b/services/config/src/types.ts
@@ -15,4 +15,6 @@ export interface Config {
     apiVersion: number
     serverVersion?: ServerVersion
     systemInfo?: SystemInfo
+    minDHIS2Version?: string
+    maxDHIS2Version?: string
 }

--- a/services/feature-toggling/.gitignore
+++ b/services/feature-toggling/.gitignore
@@ -1,0 +1,5 @@
+# DHIS2 Platform
+node_modules
+.d2
+src/locales
+build

--- a/services/feature-toggling/README.md
+++ b/services/feature-toggling/README.md
@@ -1,0 +1,11 @@
+# DHIS2 App Data Service
+
+Application configuration for [DHIS2](https://dhis2.org) applications
+
+This library is intended for use with the [DHIS2 Application Platform](https://github.com/dhis2/app-platform).
+
+## Installation
+
+This package is internal to `@dhis2/app-runtime` and generally should not be installed independently.
+
+See [the docs](https://runtime.dhis2.nu) for more.

--- a/services/feature-toggling/d2.config.js
+++ b/services/feature-toggling/d2.config.js
@@ -1,0 +1,9 @@
+const config = {
+    type: 'lib',
+
+    entryPoints: {
+        lib: './src/index.ts',
+    },
+}
+
+module.exports = config

--- a/services/feature-toggling/jest.config.js
+++ b/services/feature-toggling/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    collectCoverageFrom: [
+        'src/**/*.(js|jsx|ts|tsx)',
+        '!src/index.ts',
+        '!src/types.ts',
+    ],
+
+    // Setup react-testing-library
+    setupFilesAfterEnv: ['<rootDir>/src/setupRTL.ts'],
+}

--- a/services/feature-toggling/package.json
+++ b/services/feature-toggling/package.json
@@ -1,10 +1,9 @@
 {
-    "name": "@dhis2/app-runtime",
-    "description": "A singular runtime dependency for applications on the DHIS2 platform",
+    "name": "@dhis2/app-service-feature-toggling",
     "version": "3.2.6",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
-    "types": "./build/types/index.d.ts",
+    "types": "build/types/index.d.ts",
     "exports": {
         "import": "./build/es/index.js",
         "require": "./build/cjs/index.js"
@@ -12,7 +11,7 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/dhis2/app-runtime.git",
-        "directory": "runtime"
+        "directory": "services/feature-toggling"
     },
     "author": "Austin McGee <austin@dhis2.org>",
     "license": "BSD-3-Clause",
@@ -22,22 +21,20 @@
     "files": [
         "build/**"
     ],
-    "dependencies": {
-        "@dhis2/app-service-config": "3.2.6",
-        "@dhis2/app-service-data": "3.2.6",
-        "@dhis2/app-service-alerts": "3.2.6",
-        "@dhis2/app-service-offline": "3.2.6",
-        "@dhis2/app-service-feature-toggling": "3.2.6"
-    },
     "peerDependencies": {
         "prop-types": "^15.7.2",
         "react": "^16.8.6",
         "react-dom": "^16.8.6"
     },
     "scripts": {
+        "clean": "rimraf ./build/*",
         "build:types": "tsc --emitDeclarationOnly --outDir ./build/types",
         "build:package": "d2-app-scripts build",
         "build": "concurrently -n build,types \"yarn build:package\" \"yarn build:types\"",
-        "test": "echo \"No tests yet!\""
+        "watch": "NODE_ENV=development concurrently -n build,types \"yarn build:package --watch\" \"yarn build:types --watch\"",
+        "type-check": "tsc --noEmit --allowJs --checkJs",
+        "type-check:watch": "yarn type-check --watch",
+        "test": "d2-app-scripts test",
+        "coverage": "yarn test --coverage"
     }
 }

--- a/services/feature-toggling/src/__tests__/integration.test.tsx
+++ b/services/feature-toggling/src/__tests__/integration.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { ConfigContext } from '../ConfigContext'
+import { ConfigProvider } from '../ConfigProvider'
+import { Config } from '../types'
+
+const mockConfig: Config = {
+    baseUrl: 'http://test.com',
+    apiVersion: 42,
+    serverVersion: {
+        major: 2,
+        minor: 35,
+        patch: undefined,
+        tag: 'SNAPSHOT',
+    },
+    systemInfo: {
+        contextPath: 'http://localhost:3000',
+        version: '2.35-SNAPSHOT',
+    },
+}
+
+describe('Testing custom config provider', () => {
+    it('Should render without failing', async () => {
+        const consumerFunction = jest.fn(
+            config => `${config.baseUrl}:${config.apiVersion}`
+        )
+        const { getByText } = render(
+            <ConfigProvider config={mockConfig}>
+                <ConfigContext.Consumer>
+                    {consumerFunction}
+                </ConfigContext.Consumer>
+            </ConfigProvider>
+        )
+
+        expect(getByText(/http:\/\/test.com:42/i)).not.toBeUndefined()
+        expect(consumerFunction).toHaveBeenCalledTimes(1)
+        expect(consumerFunction).toHaveBeenLastCalledWith(mockConfig)
+    })
+})

--- a/services/feature-toggling/src/__tests__/integration.test.tsx
+++ b/services/feature-toggling/src/__tests__/integration.test.tsx
@@ -1,38 +1,26 @@
 import { render } from '@testing-library/react'
 import React from 'react'
-import { ConfigContext } from '../ConfigContext'
-import { ConfigProvider } from '../ConfigProvider'
-import { Config } from '../types'
+import { ServerVersionRangeProvider } from '../components/ServerVersionRangeProvider'
+import { ServerVersionRangeContext } from '../context/ServerVersionRangeContext'
+import { ServerVersionRange } from '../types'
 
-const mockConfig: Config = {
-    baseUrl: 'http://test.com',
-    apiVersion: 42,
-    serverVersion: {
-        major: 2,
-        minor: 35,
-        patch: undefined,
-        tag: 'SNAPSHOT',
-    },
-    systemInfo: {
-        contextPath: 'http://localhost:3000',
-        version: '2.35-SNAPSHOT',
-    },
+const mockConfig: ServerVersionRange = {
+    min: '2.34',
+    max: '2.35.2',
 }
 
 describe('Testing custom config provider', () => {
     it('Should render without failing', async () => {
-        const consumerFunction = jest.fn(
-            config => `${config.baseUrl}:${config.apiVersion}`
-        )
+        const consumerFunction = jest.fn(range => `${range.min}:${range.max}`)
         const { getByText } = render(
-            <ConfigProvider config={mockConfig}>
-                <ConfigContext.Consumer>
+            <ServerVersionRangeProvider range={{ min: '2.34', max: '2.35.2' }}>
+                <ServerVersionRangeContext.Consumer>
                     {consumerFunction}
-                </ConfigContext.Consumer>
-            </ConfigProvider>
+                </ServerVersionRangeContext.Consumer>
+            </ServerVersionRangeProvider>
         )
 
-        expect(getByText(/http:\/\/test.com:42/i)).not.toBeUndefined()
+        expect(getByText(/2.34:2.35.2/i)).not.toBeUndefined()
         expect(consumerFunction).toHaveBeenCalledTimes(1)
         expect(consumerFunction).toHaveBeenLastCalledWith(mockConfig)
     })

--- a/services/feature-toggling/src/components/ServerVersionCase.tsx
+++ b/services/feature-toggling/src/components/ServerVersionCase.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { PropsWithChildren } from 'react'
+import { ServerVersionRange } from '../types'
+import { ServerVersionRangeProvider } from './ServerVersionRangeProvider'
+
+export const ServerVersionCase = ({
+    min,
+    max,
+    children,
+}: PropsWithChildren<ServerVersionCaseProps>) => {
+    return (
+        <ServerVersionRangeProvider range={{ min, max }}>
+            {children}
+        </ServerVersionRangeProvider>
+    )
+}
+
+export type ServerVersionCaseProps = ServerVersionRange

--- a/services/feature-toggling/src/components/ServerVersionRangeProvider.tsx
+++ b/services/feature-toggling/src/components/ServerVersionRangeProvider.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { ServerVersionRangeContext } from '../context/ServerVersionRangeContext'
+import { ServerVersionRange } from '../types'
+
+const makeContext = (range: ServerVersionRange) => range
+
+export const ServerVersionRangeProvider = ({
+    range,
+    children,
+}: {
+    range: ServerVersionRange
+    children: React.ReactNode
+}) => (
+    <ServerVersionRangeContext.Provider value={makeContext(range)}>
+        {children}
+    </ServerVersionRangeContext.Provider>
+)

--- a/services/feature-toggling/src/components/ServerVersionSwitch.ts
+++ b/services/feature-toggling/src/components/ServerVersionSwitch.ts
@@ -1,28 +1,7 @@
 import { useConfig } from '@dhis2/app-service-config'
 import React from 'react'
+import { versionCompare } from '../helpers/versionCompare'
 import { ServerVersionCase, ServerVersionCaseProps } from './ServerVersionCase'
-
-const parseVersion = (v: string): number[] => {
-    return v
-        .split('.')
-        .map(segment => parseInt(segment))
-        .map(segment => (typeof segment !== 'number' ? 0 : segment))
-}
-const versionCompare = (a: string, b: string) => {
-    const parsedA = parseVersion(a)
-    const parsedB = parseVersion(b)
-    let index = 0
-    while (index++ < parsedA.length) {
-        const aValue = parsedA[index]
-        const bValue = parsedB[index] || 0
-        if (aValue > bValue) {
-            return 1
-        } else if (aValue < bValue) {
-            return -1
-        }
-    }
-    return 0
-}
 
 export const ServerVersionSwitch = ({
     children,

--- a/services/feature-toggling/src/components/ServerVersionSwitch.ts
+++ b/services/feature-toggling/src/components/ServerVersionSwitch.ts
@@ -1,0 +1,56 @@
+import { useConfig } from '@dhis2/app-service-config'
+import React from 'react'
+import { ServerVersionCase, ServerVersionCaseProps } from './ServerVersionCase'
+
+const parseVersion = (v: string): number[] => {
+    return v
+        .split('.')
+        .map(segment => parseInt(segment))
+        .map(segment => (typeof segment !== 'number' ? 0 : segment))
+}
+const versionCompare = (a: string, b: string) => {
+    const parsedA = parseVersion(a)
+    const parsedB = parseVersion(b)
+    let index = 0
+    while (index++ < parsedA.length) {
+        const aValue = parsedA[index]
+        const bValue = parsedB[index] || 0
+        if (aValue > bValue) {
+            return 1
+        } else if (aValue < bValue) {
+            return -1
+        }
+    }
+    return 0
+}
+
+export const ServerVersionSwitch = ({
+    children,
+}: {
+    children: React.ReactElement<ServerVersionCaseProps>
+}) => {
+    const { systemInfo } = useConfig()
+    const serverVersion = systemInfo?.version
+
+    let matchingChild: React.ReactElement<ServerVersionCaseProps> | null = null
+
+    React.Children.forEach(children, child => {
+        if (!matchingChild && child?.type === ServerVersionCase) {
+            const { min, max } = child.props
+            if (!min && !max) {
+                matchingChild = child
+                return
+            }
+            if (
+                serverVersion &&
+                (!min || versionCompare(min, serverVersion) <= 0) &&
+                (!max || versionCompare(max, serverVersion) >= 0)
+            ) {
+                matchingChild = child
+                return
+            }
+        }
+    })
+
+    return matchingChild
+}

--- a/services/feature-toggling/src/context/ServerVersionRangeContext.ts
+++ b/services/feature-toggling/src/context/ServerVersionRangeContext.ts
@@ -1,0 +1,9 @@
+import React from 'react'
+import { ServerVersionRange } from '../types'
+
+export const ServerVersionRangeContext = React.createContext<ServerVersionRange>(
+    {
+        min: '',
+        max: '',
+    }
+)

--- a/services/feature-toggling/src/helpers/versionCompare.test.ts
+++ b/services/feature-toggling/src/helpers/versionCompare.test.ts
@@ -1,0 +1,56 @@
+import { parseVersionString, versionCompare } from './versionCompare'
+
+describe('parseVersionString', () => {
+    it('Should correctly return [null] for an empty string', () => {
+        expect(parseVersionString('')).toMatchObject([null])
+    })
+
+    it('Should correctly parse a valid 1-part version', () => {
+        expect(parseVersionString('2')).toMatchObject([2])
+    })
+    it('Should correctly parse a valid 2-part version', () => {
+        expect(parseVersionString('2.36')).toMatchObject([2, 36])
+    })
+    it('Should correctly parse a valid 3-part version', () => {
+        expect(parseVersionString('2.34.5')).toMatchObject([2, 34, 5])
+    })
+
+    it('Should correctly parse a version with tag suffix', () => {
+        expect(parseVersionString('2.36.10-beta.3')).toMatchObject([
+            2,
+            36,
+            10,
+            null,
+            3,
+        ])
+    })
+})
+
+describe('versionCompare', () => {
+    it('Should correctly return 0 if a is equal to b', () => {
+        expect(versionCompare('2.32', '2.32')).toBe(0)
+        expect(versionCompare('2.34.6', '2.34.6')).toBe(0)
+        expect(versionCompare('2', '2')).toBe(0)
+        expect(versionCompare('2.36.10-beta.3', '2.36.10-beta.3')).toBe(0)
+    })
+    it('Should correctly return -1 if a is less than b', () => {
+        expect(versionCompare('1', '2')).toBe(-1)
+        expect(versionCompare('1.35', '2.35')).toBe(-1)
+        expect(versionCompare('2.32', '2.35')).toBe(-1)
+        expect(versionCompare('2.32.6', '2.35.3')).toBe(-1)
+        expect(versionCompare('2.35.3', '2.35.6')).toBe(-1)
+    })
+
+    it('Should correctly return 1 if a is greater than b', () => {
+        expect(versionCompare('2', '1')).toBe(1)
+        expect(versionCompare('2.35', '1.35')).toBe(1)
+        expect(versionCompare('2.35', '2.32')).toBe(1)
+        expect(versionCompare('2.35.3', '2.32.6')).toBe(1)
+        expect(versionCompare('2.35.6', '2.35.3')).toBe(1)
+    })
+
+    it('Should correctly handle postfixed versions', () => {
+        expect(versionCompare('2.36.10-beta.3', '2.36.10.0.3')).toBe(-1)
+        expect(versionCompare('2.36.10-beta.3', '2.36.10-beta.5')).toBe(-1)
+    })
+})

--- a/services/feature-toggling/src/helpers/versionCompare.ts
+++ b/services/feature-toggling/src/helpers/versionCompare.ts
@@ -1,0 +1,25 @@
+export const parseVersionString = (v: string): (number | null)[] => {
+    return v
+        .split(/[.-]/g)
+        .map(segment => parseInt(segment))
+        .map(number => (isNaN(number) ? null : number))
+}
+export const versionCompare = (a: string, b: string) => {
+    const parsedA = parseVersionString(a)
+    const parsedB = parseVersionString(b)
+    let index = 0
+    while (index < parsedA.length) {
+        const aValue = parsedA[index] ?? null
+        const bValue = parsedB[index] ?? null
+        if (aValue !== bValue) {
+            if (bValue === null || (aValue !== null && aValue > bValue)) {
+                return 1
+            }
+            if (aValue === null || aValue < bValue) {
+                return -1
+            }
+        }
+        index += 1
+    }
+    return 0
+}

--- a/services/feature-toggling/src/hooks/useServerVersionRange.ts
+++ b/services/feature-toggling/src/hooks/useServerVersionRange.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react'
+import { ServerVersionRangeContext } from '../context/ServerVersionRangeContext'
+
+export const useServerVersionRange = () => useContext(ServerVersionRangeContext)

--- a/services/feature-toggling/src/index.ts
+++ b/services/feature-toggling/src/index.ts
@@ -1,0 +1,4 @@
+export { useServerVersionRange } from './hooks/useServerVersionRange'
+export { ServerVersionRangeProvider } from './components/ServerVersionRangeProvider'
+export { ServerVersionSwitch } from './components/ServerVersionSwitch'
+export { ServerVersionCase } from './components/ServerVersionCase'

--- a/services/feature-toggling/src/setupRTL.ts
+++ b/services/feature-toggling/src/setupRTL.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom/extend-expect'
+
+process.on('unhandledRejection', err => {
+    throw err
+})

--- a/services/feature-toggling/src/types.ts
+++ b/services/feature-toggling/src/types.ts
@@ -1,0 +1,4 @@
+export interface ServerVersionRange {
+    min?: string
+    max?: string
+}

--- a/services/feature-toggling/tsconfig.json
+++ b/services/feature-toggling/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["src"],
+    "exclude": [
+        "src/setupRTL.ts",
+        "src/__tests__",
+        "**/*.test.ts",
+        "**/*.test.tsx"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,14 +1125,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
-  version "7.13.17"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
-  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.6.2":
+"@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.13.17"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
   integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
@@ -4202,9 +4195,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181:
-  version "1.0.30001192"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001192.tgz#b848ebc0ab230cf313d194a4775a30155d50ae40"
-  integrity sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw==
+  version "1.0.30001284"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001284.tgz"
+  integrity sha512-t28SKa7g6kiIQi6NHeOcKrOrGMzCRrXvlasPwWC26TH2QNdglgzQIRUuJ0cR3NeQPH+5jpuveeeSFDLm2zbkEw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
*WORK IN PROGRESS*

This introduces a new feature which supports toggling React component trees by server version range.  It can be used like so:

```jsx
import { ServerVersionSwitch, ServerVersionCase } from '@dhis2/app-runtime'
const MyApp = () => (
   <ServerVersionSwitch>
      <ServerVersionCase max="2.34">
         LEGACY CASE - Hello from a &lt;= 2.34 server!
      </ServerVersionCase>
      <ServerVersionCase min="2.35" max="2.36.2">
         SPECIAL CASE - Hello from a 2.35 or early 2.36 servers
      </ServerVersionCase>
      <ServerVersionCase>
         DEFAULT CASE - Hello from a &gt;= 2.36.3 server!
      </ServerVersionCase>
   </ServerVersionSwitch>
```

* Only the first `ServerVersionCase` which matches the current server version (from `useConfig`) will be rendered.
* A case with neither `min` nor `max` will match for any server version, i.e. it is the default case.
* The application's defined minimum and maximum versions (from `d2.config.js`) serve as the top-level min and max versions
* An error will be thrown in a version range exceeds the parent range (either another `ServerVersionRangeContext` or the top-level range).