### PR TITLE
test(use-data-mutation): add mutation tests

### DIFF
--- a/services/data/src/__tests__/integration.test.tsx
+++ b/services/data/src/__tests__/integration.test.tsx
@@ -1,32 +1,24 @@
 import { render, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { CustomDataProvider, DataQuery } from '../react'
-import { QueryRenderInput } from '../types'
 
-describe('Testing custom data provider and useQuery hook', () => {
-    it('Should render without failing', async () => {
+describe('<DataQuery />', () => {
+    it('should render without failing', async () => {
         const data = {
             answer: 42,
         }
         const wrapper = ({ children }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
-        const renderFunction = jest.fn(
-            ({ loading, error, data }: QueryRenderInput) => {
-                if (loading) return 'loading'
-                if (error) return <div>error: {error.message}</div>
-                return <div>data: {data && data.answer}</div>
-            }
-        )
+        const renderFunction = jest.fn(() => null)
 
-        const { getByText } = render(
+        render(
             <DataQuery query={{ answer: { resource: 'answer' } }}>
                 {renderFunction}
             </DataQuery>,
             { wrapper }
         )
 
-        expect(getByText(/loading/i)).not.toBeUndefined()
         expect(renderFunction).toHaveBeenCalledTimes(1)
         expect(renderFunction).toHaveBeenLastCalledWith(
             expect.objectContaining({
@@ -36,21 +28,18 @@ describe('Testing custom data provider and useQuery hook', () => {
         )
 
         await waitFor(() => {
-            getByText(/data: /i)
+            expect(renderFunction).toHaveBeenCalledTimes(2)
+            expect(renderFunction).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    called: true,
+                    loading: false,
+                    data,
+                })
+            )
         })
-
-        expect(getByText(/data: /i)).toHaveTextContent(`data: ${data.answer}`)
-        expect(renderFunction).toHaveBeenCalledTimes(2)
-        expect(renderFunction).toHaveBeenLastCalledWith(
-            expect.objectContaining({
-                called: true,
-                loading: false,
-                data,
-            })
-        )
     })
 
-    it('Should render an error', async () => {
+    it('should render an error', async () => {
         const expectedError = new Error('Something went wrong')
         const data = {
             test: () => {
@@ -60,22 +49,15 @@ describe('Testing custom data provider and useQuery hook', () => {
         const wrapper = ({ children }) => (
             <CustomDataProvider data={data}>{children}</CustomDataProvider>
         )
-        const renderFunction = jest.fn(
-            ({ loading, error, data }: QueryRenderInput) => {
-                if (loading) return 'loading'
-                if (error) return <div>error: {error.message}</div>
-                return <div>data: {data && data.test}</div>
-            }
-        )
+        const renderFunction = jest.fn(() => null)
 
-        const { getByText } = render(
+        render(
             <DataQuery query={{ test: { resource: 'test' } }}>
                 {renderFunction}
             </DataQuery>,
             { wrapper }
         )
 
-        expect(getByText(/loading/i)).not.toBeUndefined()
         expect(renderFunction).toHaveBeenCalledTimes(1)
         expect(renderFunction).toHaveBeenLastCalledWith(
             expect.objectContaining({
@@ -85,19 +67,14 @@ describe('Testing custom data provider and useQuery hook', () => {
         )
 
         await waitFor(() => {
-            getByText(/error: /i)
+            expect(renderFunction).toHaveBeenCalledTimes(2)
+            expect(renderFunction).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    called: true,
+                    loading: false,
+                    error: expectedError,
+                })
+            )
         })
-
-        expect(renderFunction).toHaveBeenCalledTimes(2)
-        expect(getByText(/error: /i)).toHaveTextContent(
-            `error: ${expectedError.message}`
-        )
-        expect(renderFunction).toHaveBeenLastCalledWith(
-            expect.objectContaining({
-                called: true,
-                loading: false,
-                error: expectedError,
-            })
-        )
     })
 })

--- a/services/data/src/react/hooks/useDataMutation.test.tsx
+++ b/services/data/src/react/hooks/useDataMutation.test.tsx
@@ -1,72 +1,294 @@
 import { renderHook, act } from '@testing-library/react-hooks'
-import React, { ReactNode } from 'react'
-import { CreateMutation } from '../../engine/types/Mutation'
+import * as React from 'react'
+import { CreateMutation, UpdateMutation } from '../../engine/types/Mutation'
 import { CustomDataProvider } from '../components/CustomDataProvider'
+import { useDataEngine } from './useDataEngine'
 import { useDataMutation } from './useDataMutation'
 
-const customData = {
-    answer: 42,
-}
+describe('useDataMutation', () => {
+    it('should render without failing', async () => {
+        const mutation: CreateMutation = {
+            type: 'create',
+            resource: 'answer',
+            data: { answer: '?' },
+        }
+        const data = { answer: 42 }
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={data}>{children}</CustomDataProvider>
+        )
 
-const wrapper = ({ children }: { children?: ReactNode }) => (
-    <CustomDataProvider data={customData}>{children}</CustomDataProvider>
-)
+        const { result, waitFor } = renderHook(
+            () => useDataMutation(mutation),
+            { wrapper }
+        )
 
-const mutation: CreateMutation = {
-    type: 'create',
-    resource: 'answer',
-    data: { answer: 42 },
-}
-describe('useDataMustation', () => {
-    const originalError = console.error
-
-    afterEach(() => {
-        console.error = originalError
-    })
-
-    it('Should render without failing', async () => {
-        let hookState: any
-
-        console.error = jest.fn()
-
-        act(() => {
-            hookState = renderHook(() => useDataMutation(mutation), {
-                wrapper,
-            })
+        const [mutate, beforeMutation] = result.current
+        expect(beforeMutation).toMatchObject({
+            loading: false,
+            called: false,
         })
-
-        let [mutate, state] = hookState.result.current
-        expect(state).toMatchObject({ called: false, loading: false })
 
         act(() => {
             mutate()
         })
 
-        mutate = hookState.result.current[0]
-        state = hookState.result.current[1]
-        expect(state).toMatchObject({ called: true, loading: true })
+        await waitFor(() => {
+            const [, duringMutation] = result.current
+            expect(duringMutation).toMatchObject({
+                loading: true,
+                called: true,
+            })
+        })
+
+        await waitFor(() => {
+            const [, afterMutation] = result.current
+            expect(afterMutation).toMatchObject({
+                loading: false,
+                called: true,
+                data: 42,
+            })
+        })
     })
 
-    it('Should run immediately with lazy: false', async () => {
-        let hookState: any
+    it('should run immediately with lazy: false', async () => {
+        const mutation: CreateMutation = {
+            type: 'create',
+            resource: 'answer',
+            data: { answer: '?' },
+        }
+        const data = { answer: 42 }
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={data}>{children}</CustomDataProvider>
+        )
 
-        console.error = jest.fn()
+        const { result, waitFor } = renderHook(
+            () => useDataMutation(mutation, { lazy: false }),
+            { wrapper }
+        )
+
+        const [, duringMutation] = result.current
+        expect(duringMutation).toMatchObject({
+            loading: true,
+            called: true,
+        })
+
+        await waitFor(() => {
+            const [, afterMutation] = result.current
+            expect(afterMutation).toMatchObject({
+                loading: false,
+                called: true,
+                data: 42,
+            })
+        })
+    })
+
+    it('should call onComplete on success', async () => {
+        const onComplete = jest.fn()
+        const mutation: CreateMutation = {
+            type: 'create',
+            resource: 'answer',
+            data: { answer: '?' },
+        }
+        const data = { answer: 42 }
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={data}>{children}</CustomDataProvider>
+        )
+
+        const { result, waitFor } = renderHook(
+            () => useDataMutation(mutation, { onComplete }),
+            { wrapper }
+        )
+
+        expect(onComplete).toHaveBeenCalledTimes(0)
+        const [mutate] = result.current
+        act(() => {
+            mutate()
+        })
+
+        await waitFor(() => {
+            const [, state] = result.current
+            expect(state).toMatchObject({
+                loading: false,
+                called: true,
+                data: 42,
+            })
+            expect(onComplete).toHaveBeenCalledTimes(1)
+            expect(onComplete).toHaveBeenLastCalledWith(42)
+        })
+    })
+
+    it('should call onError on error', async () => {
+        const error = new Error('Something went wrong')
+        const onError = jest.fn()
+        const mutation: CreateMutation = {
+            type: 'create',
+            resource: 'answer',
+            data: { answer: 42 },
+        }
+        const data = {
+            answer: () => {
+                throw error
+            },
+        }
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={data}>{children}</CustomDataProvider>
+        )
+
+        const { result, waitFor } = renderHook(
+            () => useDataMutation(mutation, { onError }),
+            { wrapper }
+        )
+
+        expect(onError).toHaveBeenCalledTimes(0)
+        const [mutate] = result.current
 
         act(() => {
-            hookState = renderHook(
-                () => useDataMutation(mutation, { lazy: false }),
-                {
-                    wrapper,
-                }
+            mutate()
+        })
+
+        await waitFor(() => {
+            const [, state] = result.current
+            expect(state).toMatchObject({
+                loading: false,
+                called: true,
+                error,
+            })
+        })
+        expect(onError).toHaveBeenCalledTimes(1)
+        expect(onError).toHaveBeenLastCalledWith(error)
+    })
+
+    it('should resolve variables', async () => {
+        const mutation: UpdateMutation = {
+            type: 'update',
+            resource: 'answer',
+            id: ({ id }) => id,
+            data: { answer: '?' },
+        }
+        const answerSpy = jest.fn(() => 42)
+        const data = { answer: answerSpy }
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={data}>{children}</CustomDataProvider>
+        )
+
+        const { result, waitFor } = renderHook(
+            () =>
+                useDataMutation(mutation, {
+                    lazy: false,
+                    variables: { id: '1' },
+                }),
+            { wrapper }
+        )
+
+        await waitFor(() => {
+            expect(answerSpy).toHaveBeenLastCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    id: '1',
+                }),
+                expect.any(Object)
             )
         })
 
-        let [, state] = hookState.result.current
-        expect(state).toMatchObject({ called: true, loading: true })
+        const [mutate] = result.current
+        act(() => {
+            mutate({ id: '2' })
+        })
 
-        await hookState.waitForNextUpdate()
+        await waitFor(() => {
+            expect(answerSpy).toHaveBeenLastCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    id: '2',
+                }),
+                expect.any(Object)
+            )
+        })
+    })
 
-        state = hookState.result.current[1]
-        expect(state).toMatchObject({ loading: false, data: 42 })
+    it('should return a reference to the engine', async () => {
+        const mutation: CreateMutation = {
+            type: 'create',
+            resource: 'answer',
+            data: { answer: '?' },
+        }
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={{}}>{children}</CustomDataProvider>
+        )
+
+        const engineHook = renderHook(() => useDataEngine(), { wrapper })
+        const mutationHook = renderHook(() => useDataMutation(mutation), {
+            wrapper,
+        })
+
+        /**
+         * Ideally we'd check referential equality here with .toBe, but since
+         * both hooks run in a different context that doesn't work.
+         */
+        expect(mutationHook.result.current[1].engine).toStrictEqual(
+            engineHook.result.current
+        )
+    })
+
+    it('should return a stable mutate function', async () => {
+        const mutation: CreateMutation = {
+            type: 'create',
+            resource: 'answer',
+            data: { answer: '?' },
+        }
+        const data = { answer: 42 }
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={data}>{children}</CustomDataProvider>
+        )
+
+        const { result } = renderHook(() => useDataMutation(mutation), {
+            wrapper,
+        })
+
+        const [firstMutate] = result.current
+
+        await act(async () => {
+            await firstMutate({ variable: 'variable' })
+        })
+
+        const [secondMutate, state] = result.current
+        expect(state).toMatchObject({
+            loading: false,
+            called: true,
+        })
+        expect(firstMutate).toBe(secondMutate)
+    })
+
+    it('should resolve with the data from mutate on success', async () => {
+        const mutation: CreateMutation = {
+            type: 'create',
+            resource: 'answer',
+            data: { answer: '?' },
+        }
+        const data = { answer: 42 }
+        const wrapper = ({ children }) => (
+            <CustomDataProvider data={data}>{children}</CustomDataProvider>
+        )
+
+        const { result, waitFor } = renderHook(
+            () => useDataMutation(mutation),
+            { wrapper }
+        )
+
+        let mutatePromise
+        const [mutate] = result.current
+        act(() => {
+            mutatePromise = mutate()
+        })
+
+        await waitFor(() => {
+            const [, state] = result.current
+            expect(state).toMatchObject({
+                loading: false,
+                called: true,
+                data: 42,
+            })
+            expect(mutatePromise).resolves.toBe(42)
+        })
     })
 })


### PR DESCRIPTION
This adds the tests from https://github.com/dhis2/app-runtime/pull/1089. Thought I'd merge these tests beforehand so that we can be sure no existing API has broken.

The act warnings don't show up when running these tests on #1089 by the way, so I've not addressed them.