### PR TITLE
fix(custom-data-link): allow falsey values for resources

### DIFF
--- a/services/data/src/links/CustomDataLink.ts
+++ b/services/data/src/links/CustomDataLink.ts
@@ -43,7 +43,7 @@ export class CustomDataLink implements DataEngineLink {
         }
 
         const customResource = this.data[query.resource]
-        if (!customResource) {
+        if (customResource === undefined) {
             if (this.failOnMiss) {
                 throw new Error(
                     `No data provided for resource type ${query.resource}!`


### PR DESCRIPTION
Currently it is not possible to use falsey (e.g. `false`, `null`, `''`, `0`, ...) values for resources when using `CustomDataProvider`.

```jsx
// This throws the error 'No data provided for resource type <resource name>!'
<CustomDataProvider data={mockData}>
  <SomeComponent />
</CustomDataProvider>
```

This PR fixes that by only treating a resource as unavailable if its value is `undefined` (when using the `CustomDataLink` link).