### PR TITLE
fix: match also eventVisualization in isCreateInterpretation

### DIFF
--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
@@ -31,7 +31,7 @@ export const isCreateInterpretation = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
 ): boolean => {
-    const pattern = /^interpretations\/(?:reportTable|chart|visualization|map|eventReport|eventChart|dataSetReport)\/[a-zA-Z0-9]{11}$/
+    const pattern = /^interpretations\/(?:reportTable|chart|visualization|map|eventVisualization|eventReport|eventChart|dataSetReport)\/[a-zA-Z0-9]{11}$/
     return type === 'create' && pattern.test(resource)
 }
 


### PR DESCRIPTION
The eventVisualization is a new endpoint that will replace eventReports.
It also sends a plain text payload when creating an interpretation.