### PR TITLE
fix: use unversioned api endpoint for tracker resource before 2.38 [LIBS-289]

### DIFF
--- a/services/config/src/index.ts
+++ b/services/config/src/index.ts
@@ -1,2 +1,4 @@
 export { useConfig } from './useConfig'
 export { ConfigProvider } from './ConfigProvider'
+
+export type { Config } from './types'

--- a/services/data/src/links/RestAPILink.ts
+++ b/services/data/src/links/RestAPILink.ts
@@ -1,3 +1,4 @@
+import type { Config } from '@dhis2/app-service-config'
 import {
     DataEngineLink,
     DataEngineLinkExecuteOptions,
@@ -10,24 +11,19 @@ import { joinPath } from './RestAPILink/path'
 import { queryToRequestOptions } from './RestAPILink/queryToRequestOptions'
 import { queryToResourcePath } from './RestAPILink/queryToResourcePath'
 
-export interface RestAPILinkInput {
-    baseUrl: string
-    apiVersion: number
-}
-
 export class RestAPILink implements DataEngineLink {
-    private apiPath: string
-    private baseUrl: string
-    private apiVersion: number
+    public readonly config: Config
+    public readonly versionedApiPath: string
+    public readonly unversionedApiPath: string
 
-    public constructor({ baseUrl, apiVersion }: RestAPILinkInput) {
-        this.baseUrl = baseUrl
-        this.apiVersion = apiVersion
-        this.apiPath = joinPath('api', String(apiVersion))
+    public constructor(config: Config) {
+        this.config = config
+        this.versionedApiPath = joinPath('api', String(config.apiVersion))
+        this.unversionedApiPath = joinPath('api')
     }
 
     private fetch(path: string, options: RequestInit): Promise<JsonValue> {
-        return fetchData(joinPath(this.baseUrl, path), options)
+        return fetchData(joinPath(this.config.baseUrl, path), options)
     }
 
     public executeResourceQuery(
@@ -36,7 +32,7 @@ export class RestAPILink implements DataEngineLink {
         { signal }: DataEngineLinkExecuteOptions
     ): Promise<JsonValue> {
         return this.fetch(
-            queryToResourcePath(this.apiPath, query, type),
+            queryToResourcePath(this, query, type),
             queryToRequestOptions(type, query, signal)
         )
     }

--- a/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
@@ -1,7 +1,20 @@
+import { Config } from '@dhis2/app-service-config'
 import { ResolvedResourceQuery } from '../../engine'
+import { RestAPILink } from '../RestAPILink'
 import { queryToResourcePath } from './queryToResourcePath'
 
-const apiPath = '<api>'
+const createLink = config => new RestAPILink(config)
+const defaultConfig: Config = {
+    basePath: '<base>',
+    apiVersion: '37',
+    serverVersion: {
+        major: 2,
+        minor: 37,
+        patch: 11
+    }
+}
+const link = createLink(defaultConfig)
+const apiPath = link.versionedApiPath
 
 const actionPrefix = `dhis-web-commons/`
 const actionPostfix = '.action'
@@ -12,7 +25,7 @@ describe('queryToResourcePath', () => {
             const query: ResolvedResourceQuery = {
                 resource: 'action::test',
             }
-            expect(queryToResourcePath(apiPath, query)).toBe(
+            expect(queryToResourcePath(link, query, 'read')).toBe(
                 `${actionPrefix}test${actionPostfix}`
             )
         })
@@ -23,7 +36,7 @@ describe('queryToResourcePath', () => {
                     key: 'value',
                 },
             }
-            expect(queryToResourcePath(apiPath, query)).toBe(
+            expect(queryToResourcePath(link, query, 'read')).toBe(
                 `${actionPrefix}test${actionPostfix}?key=value`
             )
         })
@@ -33,7 +46,7 @@ describe('queryToResourcePath', () => {
             const query: ResolvedResourceQuery = {
                 resource: 'svg.pdf',
             }
-            expect(queryToResourcePath(apiPath, query)).toBe(
+            expect(queryToResourcePath(link, query, 'read')).toBe(
                 `${apiPath}/svg.pdf`
             )
         })
@@ -42,7 +55,7 @@ describe('queryToResourcePath', () => {
         const query: ResolvedResourceQuery = {
             resource: 'test',
         }
-        expect(queryToResourcePath(apiPath, query)).toBe(`${apiPath}/test`)
+        expect(queryToResourcePath(link, query, 'read')).toBe(`${apiPath}/test`)
     })
     it('should return resource url and singular parameter separated by ?', () => {
         const query: ResolvedResourceQuery = {
@@ -51,7 +64,7 @@ describe('queryToResourcePath', () => {
                 key: 'value',
             },
         }
-        expect(queryToResourcePath(apiPath, query)).toBe(
+        expect(queryToResourcePath(link, query, 'read')).toBe(
             `${apiPath}/test?key=value`
         )
     })
@@ -63,7 +76,7 @@ describe('queryToResourcePath', () => {
                 param: 'value2',
             },
         }
-        expect(queryToResourcePath(apiPath, query)).toBe(
+        expect(queryToResourcePath(link, query, 'read')).toBe(
             `${apiPath}/test?key=value&param=value2`
         )
     })
@@ -74,7 +87,7 @@ describe('queryToResourcePath', () => {
                 'key=42&val': 'value',
             },
         }
-        expect(queryToResourcePath(apiPath, query)).toBe(
+        expect(queryToResourcePath(link, query, 'read')).toBe(
             `${apiPath}/test?key%3D42%26val=value`
         )
     })
@@ -86,7 +99,7 @@ describe('queryToResourcePath', () => {
                 param: 'value2&& 53',
             },
         }
-        expect(queryToResourcePath(apiPath, query)).toBe(
+        expect(queryToResourcePath(link, query, 'read')).toBe(
             `${apiPath}/test?key=value%3F%3D42&param=value2%26%26%2053`
         )
     })
@@ -98,7 +111,7 @@ describe('queryToResourcePath', () => {
                 param: 193.75,
             },
         }
-        expect(queryToResourcePath(apiPath, query)).toBe(
+        expect(queryToResourcePath(link, query, 'read')).toBe(
             `${apiPath}/test?key=42&param=193.75`
         )
     })
@@ -110,7 +123,7 @@ describe('queryToResourcePath', () => {
                 someflag: true,
             },
         }
-        expect(queryToResourcePath(apiPath, query)).toBe(
+        expect(queryToResourcePath(link, query, 'read')).toBe(
             `${apiPath}/test?key=42&someflag=true`
         )
     })
@@ -121,7 +134,7 @@ describe('queryToResourcePath', () => {
                 key: ['asdf', 123],
             },
         }
-        expect(queryToResourcePath(apiPath, query)).toBe(
+        expect(queryToResourcePath(link, query, 'read')).toBe(
             `${apiPath}/test?key=asdf,123`
         )
     })
@@ -132,7 +145,7 @@ describe('queryToResourcePath', () => {
                 filter: ['asdf', 123],
             },
         }
-        expect(queryToResourcePath(apiPath, query)).toBe(
+        expect(queryToResourcePath(link, query, 'read')).toBe(
             `${apiPath}/test?filter=asdf&filter=123`
         )
     })
@@ -143,7 +156,7 @@ describe('queryToResourcePath', () => {
                 key: { asdf: 'fdsa' },
             },
         }
-        expect(() => queryToResourcePath(apiPath, query)).toThrow()
+        expect(() => queryToResourcePath(link, query, 'read')).toThrow()
     })
     it('should throw if passed something crazy like a function', () => {
         const query: ResolvedResourceQuery = {
@@ -152,6 +165,32 @@ describe('queryToResourcePath', () => {
                 key: ((a: any) => a) as any,
             },
         }
-        expect(() => queryToResourcePath(apiPath, query)).toThrow()
+        expect(() => queryToResourcePath(link, query, 'read')).toThrow()
+    })
+
+    it('should return an unversioned endpoint for the new tracker importer (in version 2.37)', () => {
+        const query: ResolvedResourceQuery = {
+            resource: 'tracker'
+        }
+        expect(queryToResourcePath(link, query, 'read')).toBe(
+            `${link.unversionedApiPath}/tracker`
+        )
+    })
+
+    it('should return a VERSIONED endpoint for the new tracker importer (in version 2.38)', () => {
+        const query: ResolvedResourceQuery = {
+            resource: 'tracker'
+        }
+        const v38config: Config = {
+            ...defaultConfig,
+            serverVersion: {
+                major: 2,
+                minor: 38,
+                patch: 0
+            }
+        }
+        expect(queryToResourcePath(createLink(v38config), query, 'read')).toBe(
+            `${link.versionedApiPath}/tracker`
+        )
     })
 })

--- a/services/data/src/links/RestAPILink/queryToResourcePath.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.ts
@@ -1,9 +1,11 @@
+import type { Config } from '@dhis2/app-service-config'
 import {
     ResolvedResourceQuery,
     QueryParameters,
     QueryParameterValue,
     FetchType,
 } from '../../engine'
+import { RestAPILink } from '../RestAPILink'
 import { joinPath } from './path'
 import { validateResourceQuery } from './validateQuery'
 
@@ -69,15 +71,30 @@ const makeActionPath = (resource: string) =>
         `${resource.substr(actionPrefix.length)}.action`
     )
 
+const skipApiVersion = (resource: string, config: Config): boolean => {
+    if (resource === 'tracker') {
+        if (!config.serverVersion?.minor || config.serverVersion?.minor < 38) {
+            return true
+        }
+    }
+
+    return false
+}
+
 export const queryToResourcePath = (
-    apiPath: string,
+    link: RestAPILink,
     query: ResolvedResourceQuery,
     type: FetchType
 ): string => {
     const { resource, id, params = {} } = query
+    
+    const apiBase = skipApiVersion(resource, link.config)
+        ? link.unversionedApiPath
+        : link.versionedApiPath
+    
     const base = isAction(resource)
         ? makeActionPath(resource)
-        : joinPath(apiPath, resource, id)
+        : joinPath(apiBase, resource, id)
 
     validateResourceQuery(query, type)
 


### PR DESCRIPTION
This fixes an issue which prevented the new Tracker endpoint (/api/tracker) from being used with the App Runtime because the tracker endpoint didn't support API versioning.  This has been fixed in 2.38 and will be backported to future 2.37 and 2.36 patches, but an app developer shouldn't need to care about that.