### PR TITLE
fix: ensure refetch function has stable identity [LIBS-306]

### DIFF
--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -166,7 +166,7 @@ describe('useDataQuery', () => {
     })
 
     describe('internal: caching', () => {
-        it('Should return data from the cache if it is not stale', async () => {
+        it.only('Should return data from the cache if it is not stale', async () => {
             // Keep cached data forever, see: https://react-query.tanstack.com/reference/useQuery
             const queryClientOptions = {
                 defaultOptions: {


### PR DESCRIPTION
This refactors `useDataQuery` to store query state in a ref rather than in several state variables.  It introduces a new `refetchCount` state which is used to trigger re-renders which propagates that state to react-query.