### PR TITLE
fix: use unversioned api endpoint for tracker sub-resources

### DIFF
--- a/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
@@ -176,6 +176,16 @@ describe('queryToResourcePath', () => {
             `${link.unversionedApiPath}/tracker`
         )
     })
+    
+    it('should return an unversioned endpoint sub-resources of the new tracker importer (in version 2.37)', () => {
+        const query: ResolvedResourceQuery = {
+            resource: 'tracker/xxx',
+        }
+        expect(queryToResourcePath(link, query, 'read')).toBe(
+            `${link.unversionedApiPath}/tracker/xxx`
+        )
+    })
+
 
     it('should return a VERSIONED endpoint for the new tracker importer (in version 2.38)', () => {
         const query: ResolvedResourceQuery = {

--- a/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
@@ -179,10 +179,10 @@ describe('queryToResourcePath', () => {
     
     it('should return an unversioned endpoint sub-resources of the new tracker importer (in version 2.37)', () => {
         const query: ResolvedResourceQuery = {
-            resource: 'tracker/xxx',
+            resource: 'tracker/test',
         }
         expect(queryToResourcePath(link, query, 'read')).toBe(
-            `${link.unversionedApiPath}/tracker/xxx`
+            `${link.unversionedApiPath}/tracker/test`
         )
     })
 

--- a/services/data/src/links/RestAPILink/queryToResourcePath.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.ts
@@ -72,7 +72,7 @@ const makeActionPath = (resource: string) =>
     )
 
 const skipApiVersion = (resource: string, config: Config): boolean => {
-    if (resource === 'tracker') {
+    if (resource === 'tracker' || resource.startsWith('tracker/')) {
         if (!config.serverVersion?.minor || config.serverVersion?.minor < 38) {
             return true
         }


### PR DESCRIPTION
This fix ensures that for versions below 2.38, the `tracker` endpoint sub-resources such as `tracker/events` also use the unversioned api endpoints. This is an extension of [PR 1144](https://github.com/dhis2/app-runtime/pull/1144)