### PR TITLE
fix: ensure refetch function has stable identity [LIBS-306]

### DIFF
--- a/examples/cra/yarn.lock
+++ b/examples/cra/yarn.lock
@@ -1054,26 +1054,26 @@
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@dhis2/app-runtime@file:../../runtime":
-  version "3.2.0"
+  version "3.4.1"
   dependencies:
-    "@dhis2/app-service-alerts" "3.2.0"
-    "@dhis2/app-service-config" "3.2.0"
-    "@dhis2/app-service-data" "3.2.0"
-    "@dhis2/app-service-offline" "3.2.0"
+    "@dhis2/app-service-alerts" "3.4.1"
+    "@dhis2/app-service-config" "3.4.1"
+    "@dhis2/app-service-data" "3.4.1"
+    "@dhis2/app-service-offline" "3.4.1"
 
-"@dhis2/app-service-alerts@3.2.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.2.0"
+"@dhis2/app-service-alerts@3.4.1", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.4.1"
 
-"@dhis2/app-service-config@3.2.0", "@dhis2/app-service-config@file:../../services/config":
-  version "3.2.0"
+"@dhis2/app-service-config@3.4.1", "@dhis2/app-service-config@file:../../services/config":
+  version "3.4.1"
 
-"@dhis2/app-service-data@3.2.0", "@dhis2/app-service-data@file:../../services/data":
-  version "3.2.0"
+"@dhis2/app-service-data@3.4.1", "@dhis2/app-service-data@file:../../services/data":
+  version "3.4.1"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.2.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.2.0"
+"@dhis2/app-service-offline@3.4.1", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.4.1"
   dependencies:
     lodash "^4.17.21"
 

--- a/examples/query-playground/yarn.lock
+++ b/examples/query-playground/yarn.lock
@@ -1790,26 +1790,26 @@
     moment "^2.24.0"
 
 "@dhis2/app-runtime@*", "@dhis2/app-runtime@^2.2.2", "@dhis2/app-runtime@file:../../runtime":
-  version "3.2.0"
+  version "3.4.1"
   dependencies:
-    "@dhis2/app-service-alerts" "3.2.0"
-    "@dhis2/app-service-config" "3.2.0"
-    "@dhis2/app-service-data" "3.2.0"
-    "@dhis2/app-service-offline" "3.2.0"
+    "@dhis2/app-service-alerts" "3.4.1"
+    "@dhis2/app-service-config" "3.4.1"
+    "@dhis2/app-service-data" "3.4.1"
+    "@dhis2/app-service-offline" "3.4.1"
 
-"@dhis2/app-service-alerts@3.2.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.2.0"
+"@dhis2/app-service-alerts@3.4.1", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.4.1"
 
-"@dhis2/app-service-config@3.2.0", "@dhis2/app-service-config@file:../../services/config":
-  version "3.2.0"
+"@dhis2/app-service-config@3.4.1", "@dhis2/app-service-config@file:../../services/config":
+  version "3.4.1"
 
-"@dhis2/app-service-data@3.2.0", "@dhis2/app-service-data@file:../../services/data":
-  version "3.2.0"
+"@dhis2/app-service-data@3.4.1", "@dhis2/app-service-data@file:../../services/data":
+  version "3.4.1"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.2.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.2.0"
+"@dhis2/app-service-offline@3.4.1", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.4.1"
   dependencies:
     lodash "^4.17.21"
 

--- a/services/data/src/react/hooks/mergeAndCompareVariables.test.ts
+++ b/services/data/src/react/hooks/mergeAndCompareVariables.test.ts
@@ -1,0 +1,65 @@
+import { mergeAndCompareVariables } from './mergeAndCompareVariables'
+import { stableVariablesHash } from './stableVariablesHash'
+jest.mock('./stableVariablesHash', () => ({
+    stableVariablesHash: object => JSON.stringify(object),
+}))
+
+const testVariables = {
+    question: 'What do you get when you multiply six by nine?',
+    answer: 42,
+}
+const testHash = stableVariablesHash(testVariables)
+
+describe('mergeAndCompareVariables', () => {
+    it('Should return previous variables and hash when no new variables are provided', () => {
+        expect(
+            mergeAndCompareVariables(testVariables, undefined, undefined)
+        ).toMatchObject({
+            identical: true,
+            mergedVariables: testVariables,
+            mergedVariablesHash: undefined,
+        })
+    })
+
+    it('Should return identical: true when merged variables are identical to old variables (without prev hash)', () => {
+        const newVariables = { answer: testVariables.answer }
+
+        expect(
+            mergeAndCompareVariables(testVariables, newVariables, undefined)
+        ).toMatchObject({
+            identical: true,
+            mergedVariables: testVariables,
+            mergedVariablesHash: testHash,
+        })
+    })
+
+    it('Should return identical: false with incorrect previous hash', () => {
+        const incorrectPreviousHash = 'IAmAHash'
+        const newVariables = { answer: 42 }
+
+        expect(
+            mergeAndCompareVariables(
+                testVariables,
+                newVariables,
+                incorrectPreviousHash
+            )
+        ).toMatchObject({
+            identical: false,
+            mergedVariables: testVariables,
+            mergedVariablesHash: testHash,
+        })
+    })
+
+    it('Should return identical: false when merged variables are different than old variables', () => {
+        const newVariables = { answer: 43 }
+        const expectedMergedVariables = { ...testVariables, ...newVariables }
+
+        expect(
+            mergeAndCompareVariables(testVariables, newVariables, testHash)
+        ).toMatchObject({
+            identical: false,
+            mergedVariables: expectedMergedVariables,
+            mergedVariablesHash: stableVariablesHash(expectedMergedVariables),
+        })
+    })
+})

--- a/services/data/src/react/hooks/mergeAndCompareVariables.ts
+++ b/services/data/src/react/hooks/mergeAndCompareVariables.ts
@@ -1,0 +1,32 @@
+import type { QueryVariables } from '../../engine'
+import { stableVariablesHash } from './stableVariablesHash'
+
+export const mergeAndCompareVariables = (
+    previousVariables?: QueryVariables,
+    newVariables?: QueryVariables,
+    previousHash?: string
+) => {
+    if (!newVariables) {
+        return {
+            identical: true,
+            mergedVariablesHash: previousHash,
+            mergedVariables: previousVariables,
+        }
+    }
+
+    // Use cached hash if it exists
+    const currentHash = previousHash || stableVariablesHash(previousVariables)
+
+    const mergedVariables = {
+        ...previousVariables,
+        ...newVariables,
+    }
+    const mergedVariablesHash = stableVariablesHash(mergedVariables)
+    const identical = currentHash === mergedVariablesHash
+
+    return {
+        identical,
+        mergedVariablesHash,
+        mergedVariables,
+    }
+}

--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -426,7 +426,7 @@ describe('useDataQuery', () => {
     })
 
     describe('return values: refetch', () => {
-        it('Should trigger a request for identical variables even if stale', async () => {
+        it('Should be stable if the query variables change', async () => {
             let count = 0
             const spy = jest.fn(() => {
                 count++
@@ -451,9 +451,9 @@ describe('useDataQuery', () => {
 
             expect(spy).not.toHaveBeenCalled()
 
-            const staleRefetch = result.current.refetch
+            const initialRefetch = result.current.refetch
             act(() => {
-                staleRefetch()
+                initialRefetch()
             })
 
             await waitFor(() => {
@@ -467,7 +467,7 @@ describe('useDataQuery', () => {
             expect(spy).toHaveBeenCalledTimes(1)
 
             act(() => {
-                staleRefetch()
+                initialRefetch()
             })
 
             await waitFor(() => {
@@ -479,6 +479,7 @@ describe('useDataQuery', () => {
             })
 
             expect(spy).toHaveBeenCalledTimes(2)
+            expect(initialRefetch).toBe(result.current.refetch)
         })
 
         it('Should only trigger a single request when refetch is called on a lazy query with new variables', async () => {

--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -166,7 +166,7 @@ describe('useDataQuery', () => {
     })
 
     describe('internal: caching', () => {
-        it.only('Should return data from the cache if it is not stale', async () => {
+        it('Should return data from the cache if it is not stale', async () => {
             // Keep cached data forever, see: https://react-query.tanstack.com/reference/useQuery
             const queryClientOptions = {
                 defaultOptions: {

--- a/services/data/src/react/hooks/useDataQuery.test.tsx
+++ b/services/data/src/react/hooks/useDataQuery.test.tsx
@@ -166,7 +166,7 @@ describe('useDataQuery', () => {
     })
 
     describe('internal: caching', () => {
-        it('Should return data from the cache if it is not stale', async () => {
+        it.only('Should return data from the cache if it is not stale', async () => {
             // Keep cached data forever, see: https://react-query.tanstack.com/reference/useQuery
             const queryClientOptions = {
                 defaultOptions: {

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -150,7 +150,7 @@ export const useDataQuery = (
                 }
             })
 
-            // Trigger a react-query refetch by incrementing refetchCount state
+            // Trigger a react-query refetch by incrementing variablesUpdateCount state
             setVariablesUpdateCount(prevCount => prevCount + 1)
 
             return refetchPromise

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -41,7 +41,7 @@ export const useDataQuery = (
         warn: true,
         name: 'query',
     })
-    const [refetchCount, setRefetchCount] = useState(0)
+    const [variablesUpdateCount, setVariablesUpdateCount] = useState(0)
 
     const queryState = useRef<QueryState>({
         variables: initialVariables,
@@ -56,7 +56,7 @@ export const useDataQuery = (
 
     useDebugValue(
         {
-            refetchCount,
+            variablesUpdateCount,
             enabled: queryState.current.enabled,
             variables: queryState.current.variables,
         },
@@ -151,7 +151,7 @@ export const useDataQuery = (
             })
 
             // Trigger a react-query refetch by incrementing refetchCount state
-            setRefetchCount(prevCount => prevCount + 1)
+            setVariablesUpdateCount(prevCount => prevCount + 1)
 
             return refetchPromise
         },

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -84,10 +84,8 @@ export const useDataQuery = (
      */
 
     const onSuccess = (data: any) => {
-        if (queryState.current.refetchCallback) {
-            queryState.current.refetchCallback(data)
-            queryState.current.refetchCallback = undefined
-        }
+        queryState.current.refetchCallback?.(data)
+        queryState.current.refetchCallback = undefined
 
         if (userOnSuccess) {
             userOnSuccess(data)
@@ -96,9 +94,7 @@ export const useDataQuery = (
 
     const onError = (error: FetchError) => {
         // If we'd want to reject on errors we'd call the cb with the error here
-        if (queryState.current.refetchCallback) {
-            queryState.current.refetchCallback = undefined
-        }
+        queryState.current.refetchCallback = undefined
 
         if (userOnError) {
             userOnError(error)

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useDebugValue } from 'react'
 import { useQuery, setLogger } from 'react-query'
 import type { Query, QueryOptions, QueryVariables } from '../../engine'
-import { FetchError } from '../../engine/types/FetchError'
+import type { FetchError } from '../../engine/types/FetchError'
 import type { QueryRenderInput, QueryRefetchFunction } from '../../types'
 import { mergeAndCompareVariables } from './mergeAndCompareVariables'
 import { useDataEngine } from './useDataEngine'

--- a/services/data/src/react/hooks/useStaticInput.ts
+++ b/services/data/src/react/hooks/useStaticInput.ts
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useDebugValue } from 'react'
 
 interface StaticInputOptions {
     warn?: boolean
@@ -10,6 +10,9 @@ export const useStaticInput = <T>(
 ): [T, React.Dispatch<React.SetStateAction<T>>] => {
     const originalValue = useRef(staticValue)
     const [value, setValue] = useState<T>(() => originalValue.current)
+
+    useDebugValue(value, debugValue => `${name}: ${JSON.stringify(debugValue)}`)
+
     useEffect(() => {
         if (warn && originalValue.current !== staticValue) {
             console.warn(


### PR DESCRIPTION
- https://github.com/dhis2/app-runtime/pull/1154
- https://github.com/dhis2/app-runtime/pull/1145

Since I can't merge a failing test I've rebased 1154 on 1145. The test that fails with the code on master passes with the changes from 1154 merged in. I've updated the test a little to reflect what we want it to check with the new refetch logic.
