### PR TITLE
feat(fetch-error): expose fetch-error

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -3,6 +3,7 @@ export {
     DataProvider,
     DataQuery,
     DataMutation,
+    FetchError,
     useDataQuery,
     useDataMutation,
     useDataEngine,

--- a/services/data/src/index.ts
+++ b/services/data/src/index.ts
@@ -6,3 +6,5 @@ export {
 } from './react'
 
 export { useDataEngine, useDataQuery, useDataMutation } from './react'
+
+export { FetchError } from './engine'


### PR DESCRIPTION
It's useful to export the `FetchError` class so it can be used with `instanceOf` and be extended. 