### PR TITLE
fix(offline): clear SWR caches betwen users [LIBS-358]

### DIFF
--- a/services/offline/src/lib/__tests__/clear-sensitive-caches.test.ts
+++ b/services/offline/src/lib/__tests__/clear-sensitive-caches.test.ts
@@ -13,7 +13,7 @@ import {
 const makeCachesDeleteMock = (keys: string[]) => {
     return jest
         .fn()
-        .mockImplementation(key => Promise.resolve(keys.includes(key)))
+        .mockImplementation((key) => Promise.resolve(keys.includes(key)))
 }
 
 const keysMockDefault = jest.fn().mockImplementation(async () => [])

--- a/services/offline/src/lib/clear-sensitive-caches.ts
+++ b/services/offline/src/lib/clear-sensitive-caches.ts
@@ -5,7 +5,6 @@ export const SECTIONS_STORE = 'sections-store'
 // Non-sensitive caches that can be kept:
 const KEEPABLE_CACHES = [
     /^workbox-precache/, // precached static assets
-    /^other-assets/, // static assets cached at runtime - shouldn't be sensitive
 ]
 
 declare global {
@@ -38,17 +37,17 @@ const clearDB = async (dbName: string): Promise<void> => {
     return new Promise((resolve, reject) => {
         // IndexedDB fun:
         const openDBRequest = indexedDB.open(dbName)
-        openDBRequest.onsuccess = (e) => {
+        openDBRequest.onsuccess = e => {
             const db = (e.target as IDBOpenDBRequest).result
             const tx = db.transaction(SECTIONS_STORE, 'readwrite')
             // When the transaction completes is when the operation is done:
             tx.oncomplete = () => resolve()
-            tx.onerror = (e) => reject((e.target as IDBRequest).error)
+            tx.onerror = e => reject((e.target as IDBRequest).error)
             const os = tx.objectStore(SECTIONS_STORE)
             const clearReq = os.clear()
-            clearReq.onerror = (e) => reject((e.target as IDBRequest).error)
+            clearReq.onerror = e => reject((e.target as IDBRequest).error)
         }
-        openDBRequest.onerror = (e) => {
+        openDBRequest.onerror = e => {
             reject((e.target as IDBOpenDBRequest).error)
         }
     })
@@ -78,16 +77,16 @@ export async function clearSensitiveCaches(
         // (Resolves to 'false' because this can't detect if anything was deleted):
         clearDB(dbName).then(() => false),
         // Remove caches if not in keepable list
-        ...cacheKeys.map((key) => {
-            if (!KEEPABLE_CACHES.some((pattern) => pattern.test(key))) {
+        ...cacheKeys.map(key => {
+            if (!KEEPABLE_CACHES.some(pattern => pattern.test(key))) {
                 return caches.delete(key)
             }
             return false
         }),
-    ]).then((responses) => {
+    ]).then(responses => {
         // Return true if any caches have been cleared
         // (caches.delete() returns true if a cache is deleted successfully)
         // PWA apps can reload to restore their app shell cache
-        return responses.some((response) => response)
+        return responses.some(response => response)
     })
 }

--- a/services/offline/src/lib/clear-sensitive-caches.ts
+++ b/services/offline/src/lib/clear-sensitive-caches.ts
@@ -37,17 +37,17 @@ const clearDB = async (dbName: string): Promise<void> => {
     return new Promise((resolve, reject) => {
         // IndexedDB fun:
         const openDBRequest = indexedDB.open(dbName)
-        openDBRequest.onsuccess = e => {
+        openDBRequest.onsuccess = (e) => {
             const db = (e.target as IDBOpenDBRequest).result
             const tx = db.transaction(SECTIONS_STORE, 'readwrite')
             // When the transaction completes is when the operation is done:
             tx.oncomplete = () => resolve()
-            tx.onerror = e => reject((e.target as IDBRequest).error)
+            tx.onerror = (e) => reject((e.target as IDBRequest).error)
             const os = tx.objectStore(SECTIONS_STORE)
             const clearReq = os.clear()
-            clearReq.onerror = e => reject((e.target as IDBRequest).error)
+            clearReq.onerror = (e) => reject((e.target as IDBRequest).error)
         }
-        openDBRequest.onerror = e => {
+        openDBRequest.onerror = (e) => {
             reject((e.target as IDBOpenDBRequest).error)
         }
     })
@@ -77,16 +77,16 @@ export async function clearSensitiveCaches(
         // (Resolves to 'false' because this can't detect if anything was deleted):
         clearDB(dbName).then(() => false),
         // Remove caches if not in keepable list
-        ...cacheKeys.map(key => {
-            if (!KEEPABLE_CACHES.some(pattern => pattern.test(key))) {
+        ...cacheKeys.map((key) => {
+            if (!KEEPABLE_CACHES.some((pattern) => pattern.test(key))) {
                 return caches.delete(key)
             }
             return false
         }),
-    ]).then(responses => {
+    ]).then((responses) => {
         // Return true if any caches have been cleared
         // (caches.delete() returns true if a cache is deleted successfully)
         // PWA apps can reload to restore their app shell cache
-        return responses.some(response => response)
+        return responses.some((response) => response)
     })
 }


### PR DESCRIPTION
Part of https://dhis2.atlassian.net/browse/LIBS-356

This PR is related to but independent of https://github.com/dhis2/app-platform/pull/757

This is in case some sensitive data ends up in the SWR cache, which is intended for files to be cached at runtime, but might end up caching something `.json` or `.action` data (though those extensions are being filtered in platform PR 757 above)