### PR TITLE
fix: send POST body to indicators/expression/description as text plain

### DIFF
--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
@@ -8,6 +8,7 @@ import {
     isAddOrUpdateSystemOrUserSetting,
     addOrUpdateConfigurationProperty,
     isMetadataPackageInstallation,
+    isExpressionDescriptionValidation,
 } from './textPlainMatchers'
 
 describe('isReplyToMessageConversation', () => {
@@ -237,6 +238,23 @@ describe('isMetadataPackageInstallation', () => {
         expect(
             isMetadataPackageInstallation('create', {
                 resource: 'synchronization/somethingelse',
+            })
+        ).toBe(false)
+    })
+})
+
+describe('isExpressionDescriptionValidation', () => {
+    it('returns true for a POST to "indicators/expression/description"', () => {
+        expect(
+            isExpressionDescriptionValidation('create', {
+                resource: 'indicators/expression/description',
+            })
+        ).toBe(true)
+    })
+    it('retuns false for a POST to a different resource', () => {
+        expect(
+            isMetadataPackageInstallation('create', {
+                resource: 'indicators/expression/somethingelse',
             })
         ).toBe(false)
     })

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
@@ -121,3 +121,10 @@ export const isMetadataPackageInstallation = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
 ): boolean => type === 'create' && resource === 'synchronization/metadataPull'
+
+// POST to 'indicaators/expression/description' (validate an expression)
+export const isExpressionDescriptionValidation = (
+    type: FetchType,
+    { resource }: ResolvedResourceQuery
+): boolean =>
+    type === 'create' && resource === 'indicators/expression/description'


### PR DESCRIPTION
This is needed for the upcoming condition editor modal in DV.