### PR TITLE
fix: [DHIS2] Type generic T = QueryResult to useDataQuery

### DIFF
--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -6,6 +6,7 @@ import type { QueryRenderInput, QueryRefetchFunction } from '../../types'
 import { mergeAndCompareVariables } from './mergeAndCompareVariables'
 import { useDataEngine } from './useDataEngine'
 import { useStaticInput } from './useStaticInput'
+import {QueryResult} from "../../../build/types/engine";
 
 const noop = () => {
     /**
@@ -28,7 +29,7 @@ type QueryState = {
     refetchCallback?: (data: any) => void
 }
 
-export const useDataQuery = (
+export const useDataQuery = <T = QueryResult>(
     query: Query,
     {
         onComplete: userOnSuccess,
@@ -36,7 +37,7 @@ export const useDataQuery = (
         variables: initialVariables = {},
         lazy: initialLazy = false,
     }: QueryOptions = {}
-): QueryRenderInput => {
+): QueryRenderInput<T> => {
     const [staticQuery] = useStaticInput<Query>(query, {
         warn: true,
         name: 'query',

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -1,12 +1,11 @@
 import { useState, useRef, useCallback, useDebugValue } from 'react'
 import { useQuery, setLogger } from 'react-query'
-import type { Query, QueryOptions, QueryVariables } from '../../engine'
+import type { Query, QueryOptions, QueryResult, QueryVariables } from '../../engine'
 import type { FetchError } from '../../engine/types/FetchError'
 import type { QueryRenderInput, QueryRefetchFunction } from '../../types'
 import { mergeAndCompareVariables } from './mergeAndCompareVariables'
 import { useDataEngine } from './useDataEngine'
 import { useStaticInput } from './useStaticInput'
-import {QueryResult} from "../../../build/types/engine";
 
 const noop = () => {
     /**

--- a/services/data/src/types.ts
+++ b/services/data/src/types.ts
@@ -40,15 +40,15 @@ export interface ExecuteHookResult<ReturnType> {
     data?: ReturnType
 }
 
-export interface QueryState {
+export interface QueryState<T> {
     called: boolean
     loading: boolean
     fetching: boolean
     error?: FetchError
-    data?: QueryResult
+    data?: T
 }
 
-export interface QueryRenderInput extends QueryState {
+export interface QueryRenderInput<T = QueryResult> extends QueryState<T> {
     engine: DataEngine
     refetch: QueryRefetchFunction
 }


### PR DESCRIPTION
Hey all,

We have a use-case in capture that I think multiple projects need as well: 
We need to be able to type the `data`-object returned from the `useDataQuery`-hook. This is because the JsonMap type that is currently returned would error on almost any nested object - without giving any type safety. 

I have written a quick example in this PR, which I expect would be very wrong, but it gives you an idea of what would be a solution for us. To summarize, I've just added a generic T and mapped this to the QueryResult type. For the end user, typing is still optional.

This would allow us to type the data returned like this:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/12842868/206166156-4f247f81-9484-4a1f-8976-609b83657d1f.png">

Open for any suggestions and discussions!