### PR TITLE
fix: account for daylight savings time [LIBS-490]

### DIFF
--- a/services/config/src/__tests__/useTimeZoneConversion.test.tsx
+++ b/services/config/src/__tests__/useTimeZoneConversion.test.tsx
@@ -125,6 +125,31 @@ describe('useTimeZoneConversion', () => {
         expect(serverDate.getClientZonedISOString()).toBe(expectedDateString)
     })
 
+    it('returns fromServerDate that assumes no time zone difference if client and server time zones are the same', () => {
+        const systemInfo = {
+            ...defaultSystemInfo,
+            serverTimeZoneId: 'Africa/Kampala',
+        }
+        jest.spyOn(Intl, 'DateTimeFormat').mockReturnValue({
+            resolvedOptions: () => {
+                return {
+                    timeZone: 'Africa/Kampala',
+                }
+            },
+        } as Intl.DateTimeFormat)
+        const config = { ...defaultConfig, systemInfo }
+        const wrapper = ({ children }: { children?: ReactNode }) => (
+            <ConfigProvider config={config}>{children}</ConfigProvider>
+        )
+        const { result } = renderHook(() => useTimeZoneConversion(), {
+            wrapper,
+        })
+
+        const serverDate = result.current.fromServerDate('2010-01-01')
+        const expectedDateString = '2010-01-01T00:00:00.000'
+        expect(serverDate.getClientZonedISOString()).toBe(expectedDateString)
+    })
+
     it('returns fromServerDate with server date that matches passed time regardless of timezone', () => {
         const systemInfo = {
             ...defaultSystemInfo,

--- a/services/config/src/__tests__/useTimeZoneConversion.test.tsx
+++ b/services/config/src/__tests__/useTimeZoneConversion.test.tsx
@@ -45,6 +45,24 @@ describe('useTimeZoneConversion', () => {
         expect(serverDate.getClientZonedISOString()).toBe(expectedDateString)
     })
 
+    it('returns fromServerDate that corrects for server time zone (adjusting for summer time)', () => {
+        const systemInfo = {
+            ...defaultSystemInfo,
+            serverTimeZoneId: 'Europe/Oslo',
+        }
+        const config = { ...defaultConfig, systemInfo }
+        const wrapper = ({ children }: { children?: ReactNode }) => (
+            <ConfigProvider config={config}>{children}</ConfigProvider>
+        )
+        const { result } = renderHook(() => useTimeZoneConversion(), {
+            wrapper,
+        })
+
+        const serverDate = result.current.fromServerDate('2010-07-01')
+        const expectedDateString = '2010-06-30T22:00:00.000'
+        expect(serverDate.getClientZonedISOString()).toBe(expectedDateString)
+    })
+
     // fromServerDate accepts number, valid date string, or date object
     it('returns fromServerDate which accepts number, valid date string, or date object', () => {
         const config = { ...defaultConfig, systemInfo: defaultSystemInfo }


### PR DESCRIPTION
Implements [LIBS-490](https://dhis2.atlassian.net/browse/LIBS-490)

---

### Key features

1. fixes useTimeZoneConversion hook to adjust serverOffset relative to date

---

### Description

useTimeZoneConversion hook assumes a constant offset between client and server time zones but this offset will change throughout the year depending on whether either client or server time zone observes daylight savings time.

---

### Checklist

-   [ ] Have written Documentation
    -   This PR changes the internal implementation of the hook; the exported functions are more correct than before, but there is no change in 
-   [X] Has tests coverage
    -   test has been added covering a check for client: UTC/ server: Europe/Oslo during summer time (complements existing check during standard time)

---

### Known issues

**A)** I have updated the hook to calculate the offset except when either a) the client and server time zones are the same or b) an initial attempt at calculating the offset fails (e.g. could be due to some problem with the time zone information). The calculation of the offset isn't expensive, but we could also check if either client of server time zone observes daylight savings time, and if not memoize the offset calculation. I haven't done this as it feels a bit hacky (e.g. see [this suggested approach](https://stackoverflow.com/questions/11887934/how-to-check-if-dst-daylight-saving-time-is-in-effect-and-if-so-the-offset/11888430#11888430) on StackOverflow for determining whether time zone uses daylight savings time)

**B)** Since JavaScript only allows us to initialize a date in the client time zone, I can't think of a way to (easily) calculate the offset as of a given server time. E.g. if we get the string `2020-10-01T12:00:00` we can calculate the offset from that client time, but cannot calculate from that server time. This will lead to some inaccuracies around the point when time shifts from standard to summer time (or vice versa). For example, if we have server time zone: UTC, client time zone: Europe/Oslo and want to figure out the client equivalent of `2023-03-23T01:00:00`; the server offset at this point should be 2 hours, but if we calculate at the point it is 1am for the browser, the offset would be 1 hour (because at that point, summer time won't be implemented). So we end up with a couple of hours during which point the offset is incorrectly calculated.

I thought to address this issue it might make sense to calculate the offset from a client perspective and then test that the resulting client date when put into server time zone string (with `toLocaleString`) is correct. If not, the offset could be guessed at within ±2 hours (accounting for daylight savings time simultaneously occurring in both northern/southern hemispheres) until one presumably finds the correct one. I don't really know this would be worth it though (and also feels hacky)

Another issue that occurs to me with this is that because we allow server time zone to be a local time zone that can observe daylight savings time, we can end up in situations in which our server time differential is not unambiguously mappable to UTC (or a server time). For example, if we have server time zone: Europe/Oslo and the timestamp `2023-10-29T02:30` this could be either `2023-10-29T01:30` UTC or 2023-10-29T00:30` UTC (that is we have apparent repeat timestamps when moving from summer to standard time)

As a whole, I think I lean to being okay with this few hours of non-exactness in our system around daylight savings time (until temporal standard is introduced which should fix this). I don't think we're using dates in such a mission critical way that this will be problematic? (This isn't obviously ideal, but it seems like even if we invest time to fixing the frontend with more logic, it will still be imperfect?)


[LIBS-490]: https://dhis2.atlassian.net/browse/LIBS-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ