### PR TITLE
fix(types): add generic result type to oncomplete param

### DIFF
--- a/services/data/src/engine/types/Query.ts
+++ b/services/data/src/engine/types/Query.ts
@@ -21,9 +21,9 @@ export interface ResolvedResourceQuery extends ResourceQuery {
 export type Query = Record<string, ResourceQuery>
 export type QueryResult = JsonMap
 
-export interface QueryOptions {
+export interface QueryOptions<TQueryResult = QueryResult> {
     variables?: QueryVariables
-    onComplete?: (data: QueryResult) => void
+    onComplete?: (data: TQueryResult) => void
     onError?: (error: FetchError) => void
     lazy?: boolean
 }

--- a/services/data/src/react/hooks/useDataQuery.ts
+++ b/services/data/src/react/hooks/useDataQuery.ts
@@ -40,7 +40,7 @@ export const useDataQuery = <TQueryResult = QueryResult>(
         onError: userOnError,
         variables: initialVariables = {},
         lazy: initialLazy = false,
-    }: QueryOptions = {}
+    }: QueryOptions<TQueryResult> = {}
 ): QueryRenderInput<TQueryResult> => {
     const [staticQuery] = useStaticInput<Query>(query, {
         warn: true,


### PR DESCRIPTION

---

### Key features

<!-- Remove if not applicable -->

1. Fixes typing for onComplete data-param

---

### Description

Adds a TQueryResult type for `onComplete` in `QueryOptions`


---

