### PR TITLE
feat: add login settings hook [LIBS-516]

### DIFF
--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -16,7 +16,8 @@
         "@dhis2/app-service-alerts": "file:../../services/alerts",
         "@dhis2/app-service-config": "file:../../services/config",
         "@dhis2/app-service-data": "file:../../services/data",
-        "@dhis2/app-service-offline": "file:../../services/offline"
+        "@dhis2/app-service-offline": "file:../../services/offline",
+        "@dhis2/app-service-login-settings": "file:../../services/login-settings"
     },
     "scripts": {
         "start": "react-scripts start",

--- a/examples/cra/yarn.lock
+++ b/examples/cra/yarn.lock
@@ -1054,26 +1054,30 @@
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@dhis2/app-runtime@file:../../runtime":
-  version "3.6.1"
+  version "3.9.4"
   dependencies:
-    "@dhis2/app-service-alerts" "3.6.1"
-    "@dhis2/app-service-config" "3.6.1"
-    "@dhis2/app-service-data" "3.6.1"
-    "@dhis2/app-service-offline" "3.6.1"
+    "@dhis2/app-service-alerts" "3.9.4"
+    "@dhis2/app-service-config" "3.9.4"
+    "@dhis2/app-service-data" "3.9.4"
+    "@dhis2/app-service-login-settings" "3.9.4"
+    "@dhis2/app-service-offline" "3.9.4"
 
-"@dhis2/app-service-alerts@3.6.1", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.6.1"
+"@dhis2/app-service-alerts@3.9.4", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.9.4"
 
-"@dhis2/app-service-config@3.6.1", "@dhis2/app-service-config@file:../../services/config":
-  version "3.6.1"
+"@dhis2/app-service-config@3.9.4", "@dhis2/app-service-config@file:../../services/config":
+  version "3.9.4"
 
-"@dhis2/app-service-data@3.6.1", "@dhis2/app-service-data@file:../../services/data":
-  version "3.6.1"
+"@dhis2/app-service-data@3.9.4", "@dhis2/app-service-data@file:../../services/data":
+  version "3.9.4"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.6.1", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.6.1"
+"@dhis2/app-service-login-settings@3.9.4", "@dhis2/app-service-login-settings@file:../../services/login-settings":
+  version "3.9.4"
+
+"@dhis2/app-service-offline@3.9.4", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.9.4"
   dependencies:
     lodash "^4.17.21"
 

--- a/examples/query-playground/package.json
+++ b/examples/query-playground/package.json
@@ -29,6 +29,7 @@
         "@dhis2/app-service-alerts": "file:../../services/alerts",
         "@dhis2/app-service-config": "file:../../services/config",
         "@dhis2/app-service-data": "file:../../services/data",
-        "@dhis2/app-service-offline": "file:../../services/offline"
+        "@dhis2/app-service-offline": "file:../../services/offline",
+        "@dhis2/app-service-login-settings": "file:../../services/login-settings"
     }
 }

--- a/examples/query-playground/yarn.lock
+++ b/examples/query-playground/yarn.lock
@@ -1800,26 +1800,30 @@
     "@dhis2/app-service-offline" "3.7.0"
 
 "@dhis2/app-runtime@^2.2.2", "@dhis2/app-runtime@file:../../runtime":
-  version "3.6.1"
+  version "3.9.4"
   dependencies:
-    "@dhis2/app-service-alerts" "3.6.1"
-    "@dhis2/app-service-config" "3.6.1"
-    "@dhis2/app-service-data" "3.6.1"
-    "@dhis2/app-service-offline" "3.6.1"
+    "@dhis2/app-service-alerts" "3.9.4"
+    "@dhis2/app-service-config" "3.9.4"
+    "@dhis2/app-service-data" "3.9.4"
+    "@dhis2/app-service-login-settings" "3.9.4"
+    "@dhis2/app-service-offline" "3.9.4"
 
-"@dhis2/app-service-alerts@3.6.1", "@dhis2/app-service-alerts@3.7.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.6.1"
+"@dhis2/app-service-alerts@3.7.0", "@dhis2/app-service-alerts@3.9.4", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.9.4"
 
-"@dhis2/app-service-config@3.6.1", "@dhis2/app-service-config@3.7.0", "@dhis2/app-service-config@file:../../services/config":
-  version "3.6.1"
+"@dhis2/app-service-config@3.7.0", "@dhis2/app-service-config@3.9.4", "@dhis2/app-service-config@file:../../services/config":
+  version "3.9.4"
 
-"@dhis2/app-service-data@3.6.1", "@dhis2/app-service-data@3.7.0", "@dhis2/app-service-data@file:../../services/data":
-  version "3.6.1"
+"@dhis2/app-service-data@3.7.0", "@dhis2/app-service-data@3.9.4", "@dhis2/app-service-data@file:../../services/data":
+  version "3.9.4"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.6.1", "@dhis2/app-service-offline@3.7.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.6.1"
+"@dhis2/app-service-login-settings@3.9.4", "@dhis2/app-service-login-settings@file:../../services/login-settings":
+  version "3.9.4"
+
+"@dhis2/app-service-offline@3.7.0", "@dhis2/app-service-offline@3.9.4", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.9.4"
   dependencies:
     lodash "^4.17.21"
 

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -26,7 +26,8 @@
         "@dhis2/app-service-config": "3.9.4",
         "@dhis2/app-service-data": "3.9.4",
         "@dhis2/app-service-alerts": "3.9.4",
-        "@dhis2/app-service-offline": "3.9.4"
+        "@dhis2/app-service-offline": "3.9.4",
+        "@dhis2/app-service-login-settings": "3.9.4"
     },
     "peerDependencies": {
         "prop-types": "^15.7.2",

--- a/runtime/src/Provider.tsx
+++ b/runtime/src/Provider.tsx
@@ -2,6 +2,7 @@ import { AlertsProvider } from '@dhis2/app-service-alerts'
 import { ConfigProvider } from '@dhis2/app-service-config'
 import { Config } from '@dhis2/app-service-config/build/types/types'
 import { DataProvider } from '@dhis2/app-service-data'
+import { LoginSettingsProvider } from '@dhis2/app-service-login-settings'
 import { OfflineProvider } from '@dhis2/app-service-offline'
 import React from 'react'
 
@@ -9,17 +10,26 @@ type ProviderInput = {
     config: Config
     children: React.ReactNode
     offlineInterface?: any // temporary until offline service has types
+    loginApp: boolean
 }
+
 export const Provider = ({
     config,
     children,
     offlineInterface,
+    loginApp,
 }: ProviderInput) => (
     <ConfigProvider config={config}>
         <AlertsProvider>
             <DataProvider>
                 <OfflineProvider offlineInterface={offlineInterface}>
-                    {children}
+                    {loginApp ? (
+                        <LoginSettingsProvider>
+                            {children}
+                        </LoginSettingsProvider>
+                    ) : (
+                        <>{children}</>
+                    )}
                 </OfflineProvider>
             </DataProvider>
         </AlertsProvider>

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -23,4 +23,6 @@ export {
     clearSensitiveCaches,
 } from '@dhis2/app-service-offline'
 
+export { useLoginSettings } from '@dhis2/app-service-login-settings'
+
 export { Provider } from './Provider'

--- a/services/login-settings/.gitignore
+++ b/services/login-settings/.gitignore
@@ -1,0 +1,5 @@
+# DHIS2 Platform
+node_modules
+.d2
+src/locales
+build

--- a/services/login-settings/README.md
+++ b/services/login-settings/README.md
@@ -1,0 +1,11 @@
+# DHIS2 App Login Settings Service
+
+This service exposes system settings needed for login applications for [DHIS2](https://dhis2.org).
+
+This library is intended for use with the [DHIS2 Application Platform](https://github.com/dhis2/app-platform).
+
+## Installation
+
+This package is internal to `@dhis2/app-runtime` and generally should not be installed independently.
+
+See [the docs](https://runtime.dhis2.nu) for more.

--- a/services/login-settings/d2.config.js
+++ b/services/login-settings/d2.config.js
@@ -1,0 +1,9 @@
+const config = {
+    type: 'lib',
+
+    entryPoints: {
+        lib: './src/index.ts',
+    },
+}
+
+module.exports = config

--- a/services/login-settings/jest.config.js
+++ b/services/login-settings/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+    collectCoverageFrom: [
+        'src/**/*.(js|jsx|ts|tsx)',
+        '!src/index.ts',
+        '!src/**/types/*',
+        '!src/**/types.ts',
+    ],
+
+    // Setup react-testing-library
+    setupFilesAfterEnv: ['<rootDir>/src/setupRTL.ts'],
+    // Fix for Jest 27
+    // https://github.com/facebook/jest/issues/11404#issuecomment-1003328922
+    testRunner: 'jest-jasmine2',
+}

--- a/services/login-settings/package.json
+++ b/services/login-settings/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@dhis2/app-service-login-settings",
+    "description": "A runtime service for login settings",
+    "version": "3.9.4",
+    "main": "./build/cjs/index.js",
+    "module": "./build/es/index.js",
+    "types": "build/types/index.d.ts",
+    "exports": {
+        "import": "./build/es/index.js",
+        "require": "./build/cjs/index.js"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dhis2/app-runtime.git",
+        "directory": "services/login-settings"
+    },
+    "author": "Thomas Zemp <tom@dhis2.org>",
+    "license": "BSD-3-Clause",
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "build/**"
+    ],
+    "scripts": {
+        "build:types": "tsc --emitDeclarationOnly --outDir ./build/types",
+        "build:package": "d2-app-scripts build",
+        "build": "concurrently -n build,types \"yarn build:package\" \"yarn build:types\"",
+        "watch": "NODE_ENV=development concurrently -n build,types \"yarn build:package --watch\" \"yarn build:types --watch\"",
+        "type-check": "tsc --noEmit --allowJs --checkJs",
+        "type-check:watch": "yarn type-check --watch",
+        "test": "d2-app-scripts test",
+        "coverage": "yarn test --coverage"
+    },
+    "peerDependencies": {
+        "@dhis2/app-service-config": "3.9.4",
+        "prop-types": "^15.7.2",
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
+    }
+}

--- a/services/login-settings/src/LoginSettingsContext.ts
+++ b/services/login-settings/src/LoginSettingsContext.ts
@@ -17,7 +17,6 @@ export const LoginSettingsContext = React.createContext<LoginSettings>({
     systemUiLocale: '',
     uiLocale: '',
     localesUI: [],
-    dir: '',
     htmlTemplate: '',
     refreshOnTranslation: ({ locale }) => {
         throw new Error('This function is not implemented')

--- a/services/login-settings/src/LoginSettingsContext.ts
+++ b/services/login-settings/src/LoginSettingsContext.ts
@@ -1,0 +1,27 @@
+import React from 'react'
+import { LoginSettings } from './types'
+
+export const LoginSettingsContext = React.createContext<LoginSettings>({
+    applicationDescription: '',
+    applicationFooter: '',
+    applicationNotification: '',
+    allowAccountRecovery: false,
+    applicationTitle: '',
+    countryFlag: '',
+    useCountryFlag: false,
+    loginPageLogo: '',
+    useLoginPageLogo: false,
+    emailConfigured: false,
+    selfRegistrationEnabled: false,
+    selfRegistrationNoRecaptcha: false,
+    systemUiLocale: '',
+    uiLocale: '',
+    localesUI: [],
+    dir: '',
+    htmlTemplate: '',
+    refreshOnTranslation: ({ locale }) => {
+        throw new Error('This function is not implemented')
+    },
+    error: null,
+    called: false,
+})

--- a/services/login-settings/src/LoginSettingsProvider.tsx
+++ b/services/login-settings/src/LoginSettingsProvider.tsx
@@ -1,0 +1,103 @@
+// import i18n from '@dhis2/d2-i18n'
+import { useDataQuery } from '@dhis2/app-service-data'
+import React, { useState } from 'react'
+import { LoginSettingsContext } from './LoginSettingsContext'
+import { LoginSettings, Locale } from './types'
+
+const querySettings = {
+    loginSettings: {
+        resource: 'auth/loginConfig',
+        params: ({ locale }: any) =>
+            locale
+                ? {
+                      paging: false,
+                      locale,
+                  }
+                : {
+                      paging: false,
+                  },
+    },
+}
+
+const queryLocales = {
+    localesUI: {
+        resource: 'locales/ui',
+    },
+}
+
+const localStorageLocaleKey = 'dhis2.locale.ui'
+
+const defaultLocales = [
+    { locale: 'en', name: 'English', displayName: 'English' },
+]
+
+const transformFetchedLocales = (fetchedLocales: any): Locale[] => {
+    if (Array.isArray(fetchedLocales)) {
+        return fetchedLocales.map((locale) => ({
+            name: locale?.name,
+            locale: locale?.locale,
+            displayName: locale?.displayName,
+        }))
+    }
+    return defaultLocales
+}
+
+const getLocale = (
+    selectedLocale: string | null,
+    systemUiLocale: string | undefined
+): string => {
+    if (selectedLocale !== null) {
+        return selectedLocale
+    }
+    if (systemUiLocale) {
+        return systemUiLocale
+    }
+    return 'en'
+}
+
+export const LoginSettingsProvider = ({
+    children,
+}: {
+    children: React.ReactNode
+}) => {
+    const { data, called, error, refetch } = useDataQuery(querySettings, {
+        variables: { locale: localStorage[localStorageLocaleKey] },
+    })
+
+    const {
+        data: dataLocales,
+        called: calledLocales,
+        error: errorLocales,
+    } = useDataQuery(queryLocales)
+
+    const [selectedLocale, setSelectedLocale] = useState(
+        window.localStorage.getItem(localStorageLocaleKey)
+    )
+
+    const refreshOnTranslation = ({ locale }: { locale: string }) => {
+        refetch({ locale })
+        setSelectedLocale(locale)
+        localStorage.setItem(localStorageLocaleKey, locale)
+    }
+
+    const fetchedLoginSettings: any =
+        typeof data?.loginSettings === 'object' ? data.loginSettings : {}
+
+    const providerValue = {
+        ...fetchedLoginSettings,
+        uiLocale: getLocale(
+            selectedLocale,
+            fetchedLoginSettings?.systemUiLocale
+        ),
+        localesUI: transformFetchedLocales(dataLocales?.localesUI),
+        refreshOnTranslation,
+        error: error || errorLocales,
+        called: called && calledLocales,
+    }
+
+    return (
+        <LoginSettingsContext.Provider value={providerValue}>
+            {children}
+        </LoginSettingsContext.Provider>
+    )
+}

--- a/services/login-settings/src/LoginSettingsProvider.tsx
+++ b/services/login-settings/src/LoginSettingsProvider.tsx
@@ -55,6 +55,30 @@ const getLocale = (
     return 'en'
 }
 
+const getDefaultSettings = (): LoginSettings => ({
+    applicationDescription:
+        'This is the long application subtitle where there is a lot of information included in the subtitle so it must handle this much information',
+    applicationFooter: 'Application left side footer text',
+    applicationNotification:
+        'this is placeholder for the application notification.',
+    allowAccountRecovery: true,
+    applicationTitle: 'Example application title that could be very long',
+    countryFlag: 'http://localhost:8080/dhis-web-commons/flags/norway.png',
+    useCountryFlag: true,
+    loginPageLogo: 'http://localhost:8080/api/staticContent/logo_front',
+    useLoginPageLogo: true,
+    emailConfigured: true,
+    selfRegistrationEnabled: true,
+    selfRegistrationNoRecaptcha: false,
+    systemUiLocale: 'en',
+    uiLocale: 'en',
+    localesUI: defaultLocales,
+    htmlTemplate: 'standard',
+    refreshOnTranslation: ({ locale }) => {
+        throw new Error('This function is not implemented')
+    },
+})
+
 export const LoginSettingsProvider = ({
     children,
 }: {
@@ -84,6 +108,7 @@ export const LoginSettingsProvider = ({
         typeof data?.loginSettings === 'object' ? data.loginSettings : {}
 
     const providerValue = {
+        ...getDefaultSettings(),
         ...fetchedLoginSettings,
         uiLocale: getLocale(
             selectedLocale,

--- a/services/login-settings/src/__tests__/integration.test.tsx
+++ b/services/login-settings/src/__tests__/integration.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { LoginSettingsContext } from '../LoginSettingsContext'
+import { LoginSettingsProvider } from '../LoginSettingsProvider'
+
+describe('LoginSettings Context', () => {
+    it('Should return default values if query fails', async () => {
+        // no DHIS2 Data context is initialized, so provider will fall back to default values
+        const queryClient = new QueryClient()
+        const consumerFunction = jest.fn(
+            (loginSettings) => `${loginSettings.uiLocale}`
+        )
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <LoginSettingsProvider>
+                    <LoginSettingsContext.Consumer>
+                        {consumerFunction}
+                    </LoginSettingsContext.Consumer>
+                </LoginSettingsProvider>
+            </QueryClientProvider>
+        )
+
+        expect(getByText('en')).not.toBeUndefined()
+        expect(consumerFunction).toHaveBeenCalledTimes(1)
+    })
+})

--- a/services/login-settings/src/index.ts
+++ b/services/login-settings/src/index.ts
@@ -1,0 +1,3 @@
+export { useLoginSettings } from './useLoginSettings'
+export { LoginSettingsContext } from './LoginSettingsContext'
+export { LoginSettingsProvider } from './LoginSettingsProvider'

--- a/services/login-settings/src/setupRTL.ts
+++ b/services/login-settings/src/setupRTL.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'

--- a/services/login-settings/src/types.ts
+++ b/services/login-settings/src/types.ts
@@ -1,0 +1,28 @@
+export interface Locale {
+    locale: string
+    name: string
+    displayName?: string
+}
+
+export interface LoginSettings {
+    applicationDescription?: string
+    applicationFooter?: string
+    applicationNotification?: string
+    allowAccountRecovery?: boolean
+    applicationTitle?: string
+    countryFlag?: string
+    useCountryFlag?: boolean
+    loginPageLogo?: string
+    useLoginPageLogo?: boolean
+    emailConfigured?: boolean
+    selfRegistrationEnabled?: boolean
+    selfRegistrationNoRecaptcha?: boolean
+    systemUiLocale?: string
+    uiLocale?: string
+    localesUI?: Locale[]
+    dir?: string
+    htmlTemplate?: string
+    refreshOnTranslation?: ({ locale }: { locale: string }) => void
+    error?: Error | null
+    called?: boolean
+}

--- a/services/login-settings/src/types.ts
+++ b/services/login-settings/src/types.ts
@@ -20,7 +20,6 @@ export interface LoginSettings {
     systemUiLocale?: string
     uiLocale?: string
     localesUI?: Locale[]
-    dir?: string
     htmlTemplate?: string
     refreshOnTranslation?: ({ locale }: { locale: string }) => void
     error?: Error | null

--- a/services/login-settings/src/useLoginSettings.ts
+++ b/services/login-settings/src/useLoginSettings.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react'
+import { LoginSettingsContext } from './LoginSettingsContext'
+
+export const useLoginSettings = () => useContext(LoginSettingsContext)

--- a/services/login-settings/tsconfig.json
+++ b/services/login-settings/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["src"],
+    "exclude": [
+        "src/setupRTL.ts",
+        "src/__tests__",
+        "**/*.test.ts",
+        "**/*.test.tsx"
+    ]
+}


### PR DESCRIPTION
Implements [LIBS-516](https://dhis2.atlassian.net/browse/LIBS-516)

---

### Key features

<!-- Remove if not applicable -->

1. Adds a hook (`useLoginSettings`) that can be used 

---

### Description

**NOTE: This PR assumes changes to backend endpoints that have not yet been implemented.**

The purpose of this change is to make relevant login settings easily accessible in dhis2-ui login components and to simplify retrieval of login settings within a custom login app. The overall goal of this is to make it easier for external developers to build their own custom login apps.

Note: I've added notes on the code with some specific questions / points of consideration.

---

### Checklist

-   [ ] Have written Documentation
    -   I haven't yet added documentation as this PR is just a draft and is not intended to be merged (it exists mainly for discussion/testing at this point)
-   [ ] Has tests coverage
    -   See above point. More tests will need to be added if we actually want to use this.

---

### Known issues

<!-- Remove if not applicable -->

-  Note: this would be designed to run with a new `login_app` app type (see https://github.com/dhis2/app-platform/pull/788)




[LIBS-516]: https://dhis2.atlassian.net/browse/LIBS-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ