### PR TITLE
fix: add back plugin service dependency [LIBS-583]

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -26,7 +26,8 @@
         "@dhis2/app-service-config": "3.10.0-alpha.5",
         "@dhis2/app-service-data": "3.10.0-alpha.5",
         "@dhis2/app-service-alerts": "3.10.0-alpha.5",
-        "@dhis2/app-service-offline": "3.10.0-alpha.5"
+        "@dhis2/app-service-offline": "3.10.0-alpha.5",
+        "@dhis2/app-service-plugin": "3.10.0-alpha.5"
     },
     "peerDependencies": {
         "prop-types": "^15.7.2",


### PR DESCRIPTION
Implements [LIBS-538](https://dhis2.atlassian.net/browse/LIBS-538)

---

### Description

Adds back plugin dependency that was removed when master branch was merged into alpha.

---

### Checklist

-   [ ] Have written Documentation
    -   this is a bug fix
-   [ ] Has tests coverage
    -   can be handled later as part of general work to add in tests for handling plugin wrappers (I guess testing an import of a plugin in a sample app?)

---


[LIBS-538]: https://dhis2.atlassian.net/browse/LIBS-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ