### PR TITLE
chore: update verify-lib action to run on PRs

### DIFF
--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -1,8 +1,6 @@
 name: 'dhis2: verify (lib)'
 
-on:
-    push:
-        branches:
+on: [push, pull_request]
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'


### PR DESCRIPTION
trying to avoid the issue described here - https://github.com/orgs/community/discussions/26148#discussioncomment-3250574 which causes a PR to get stuck waiting for runs when created from an already existing branch like alpha that didn't have pushes to trigger the CI run.