### PR TITLE
chore: revert change for skipping linting commits

### DIFF
--- a/.github/workflows/dhis2-verify-commits.yml
+++ b/.github/workflows/dhis2-verify-commits.yml
@@ -19,7 +19,7 @@ jobs:
 
     lint-commits:
         runs-on: ubuntu-latest
-        if: ${{ !contains(github.event.pull_request.title, '[skip release]') }}
+        # if: ${{ !contains(github.event.pull_request.title, '[skip release]') }}
         steps:
             - uses: actions/checkout@v2
               with:


### PR DESCRIPTION
revert the change to omit linting based on PR title, since it can have the side effect of a PR being merged to master with skip-release which doesn't only skip the linting, but also the release