### PR TITLE
chore: allow for unversioned api links

### DIFF
--- a/examples/cra/yarn.lock
+++ b/examples/cra/yarn.lock
@@ -1054,32 +1054,32 @@
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
 "@dhis2/app-runtime@file:../../runtime":
-  version "3.10.0-alpha.2"
+  version "3.10.2"
   dependencies:
-    "@dhis2/app-service-alerts" "3.10.0-alpha.2"
-    "@dhis2/app-service-config" "3.10.0-alpha.2"
-    "@dhis2/app-service-data" "3.10.0-alpha.2"
-    "@dhis2/app-service-offline" "3.10.0-alpha.2"
-    "@dhis2/app-service-plugin" "3.10.0-alpha.2"
+    "@dhis2/app-service-alerts" "3.10.2"
+    "@dhis2/app-service-config" "3.10.2"
+    "@dhis2/app-service-data" "3.10.2"
+    "@dhis2/app-service-offline" "3.10.2"
+    "@dhis2/app-service-plugin" "3.10.2"
 
-"@dhis2/app-service-alerts@3.10.0-alpha.2", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-alerts@3.10.2", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.10.2"
 
-"@dhis2/app-service-config@3.10.0-alpha.2", "@dhis2/app-service-config@file:../../services/config":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-config@3.10.2", "@dhis2/app-service-config@file:../../services/config":
+  version "3.10.2"
 
-"@dhis2/app-service-data@3.10.0-alpha.2", "@dhis2/app-service-data@file:../../services/data":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-data@3.10.2", "@dhis2/app-service-data@file:../../services/data":
+  version "3.10.2"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.10.0-alpha.2", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-offline@3.10.2", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.10.2"
   dependencies:
     lodash "^4.17.21"
 
-"@dhis2/app-service-plugin@3.10.0-alpha.2", "@dhis2/app-service-plugin@file:../../services/plugin":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-plugin@3.10.2", "@dhis2/app-service-plugin@file:../../services/plugin":
+  version "3.10.2"
   dependencies:
     post-robot "^10.0.46"
 

--- a/examples/query-playground/yarn.lock
+++ b/examples/query-playground/yarn.lock
@@ -1800,32 +1800,32 @@
     "@dhis2/app-service-offline" "3.8.0"
 
 "@dhis2/app-runtime@^2.2.2", "@dhis2/app-runtime@file:../../runtime":
-  version "3.10.0-alpha.2"
+  version "3.10.2"
   dependencies:
-    "@dhis2/app-service-alerts" "3.10.0-alpha.2"
-    "@dhis2/app-service-config" "3.10.0-alpha.2"
-    "@dhis2/app-service-data" "3.10.0-alpha.2"
-    "@dhis2/app-service-offline" "3.10.0-alpha.2"
-    "@dhis2/app-service-plugin" "3.10.0-alpha.2"
+    "@dhis2/app-service-alerts" "3.10.2"
+    "@dhis2/app-service-config" "3.10.2"
+    "@dhis2/app-service-data" "3.10.2"
+    "@dhis2/app-service-offline" "3.10.2"
+    "@dhis2/app-service-plugin" "3.10.2"
 
-"@dhis2/app-service-alerts@3.10.0-alpha.2", "@dhis2/app-service-alerts@3.8.0", "@dhis2/app-service-alerts@file:../../services/alerts":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-alerts@3.10.2", "@dhis2/app-service-alerts@3.8.0", "@dhis2/app-service-alerts@file:../../services/alerts":
+  version "3.10.2"
 
-"@dhis2/app-service-config@3.10.0-alpha.2", "@dhis2/app-service-config@3.8.0", "@dhis2/app-service-config@file:../../services/config":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-config@3.10.2", "@dhis2/app-service-config@3.8.0", "@dhis2/app-service-config@file:../../services/config":
+  version "3.10.2"
 
-"@dhis2/app-service-data@3.10.0-alpha.2", "@dhis2/app-service-data@3.8.0", "@dhis2/app-service-data@file:../../services/data":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-data@3.10.2", "@dhis2/app-service-data@3.8.0", "@dhis2/app-service-data@file:../../services/data":
+  version "3.10.2"
   dependencies:
     react-query "^3.13.11"
 
-"@dhis2/app-service-offline@3.10.0-alpha.2", "@dhis2/app-service-offline@3.8.0", "@dhis2/app-service-offline@file:../../services/offline":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-offline@3.10.2", "@dhis2/app-service-offline@3.8.0", "@dhis2/app-service-offline@file:../../services/offline":
+  version "3.10.2"
   dependencies:
     lodash "^4.17.21"
 
-"@dhis2/app-service-plugin@3.10.0-alpha.2", "@dhis2/app-service-plugin@file:../../services/plugin":
-  version "3.10.0-alpha.2"
+"@dhis2/app-service-plugin@3.10.2", "@dhis2/app-service-plugin@file:../../services/plugin":
+  version "3.10.2"
   dependencies:
     post-robot "^10.0.46"
 

--- a/runtime/src/Provider.tsx
+++ b/runtime/src/Provider.tsx
@@ -12,6 +12,7 @@ type ProviderInput = {
     plugin: boolean
     parentAlertsAdd: any
     showAlertsInPlugin: boolean
+    skipApiVersion: boolean
 }
 export const Provider = ({
     config,
@@ -20,6 +21,7 @@ export const Provider = ({
     plugin,
     parentAlertsAdd,
     showAlertsInPlugin,
+    skipApiVersion,
 }: ProviderInput) => (
     <ConfigProvider config={config}>
         <AlertsProvider
@@ -27,7 +29,7 @@ export const Provider = ({
             parentAlertsAdd={parentAlertsAdd}
             showAlertsInPlugin={showAlertsInPlugin}
         >
-            <DataProvider>
+            <DataProvider skipApiVersion={skipApiVersion}>
                 <OfflineProvider offlineInterface={offlineInterface}>
                     {children}
                 </OfflineProvider>

--- a/services/config/src/index.ts
+++ b/services/config/src/index.ts
@@ -2,4 +2,4 @@ export { useConfig } from './useConfig'
 export { useTimeZoneConversion } from './useTimeZoneConversion'
 export { ConfigProvider } from './ConfigProvider'
 
-export type { Config, Version } from './types'
+export type { Config, ConfigWithSkipApiVersion, Version } from './types'

--- a/services/config/src/types.ts
+++ b/services/config/src/types.ts
@@ -22,3 +22,7 @@ export interface Config {
     serverVersion?: Version
     systemInfo?: SystemInfo
 }
+
+export interface ConfigWithSkipApiVersion extends Config {
+    skipApiVersion?: boolean
+}

--- a/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
@@ -1,4 +1,4 @@
-import { Config } from '@dhis2/app-service-config'
+import { Config, ConfigWithSkipApiVersion } from '@dhis2/app-service-config'
 import { ResolvedResourceQuery } from '../../engine'
 import { RestAPILink } from '../RestAPILink'
 import { queryToResourcePath } from './queryToResourcePath'
@@ -201,5 +201,18 @@ describe('queryToResourcePath', () => {
         expect(queryToResourcePath(createLink(v38config), query, 'read')).toBe(
             `${link.versionedApiPath}/tracker`
         )
+    })
+
+    it('should return a unversioned endpoint if config.skipApiVersion is true', () => {
+        const query: ResolvedResourceQuery = {
+            resource: 'loginConfig',
+        }
+        const skipApiVersionConfig: ConfigWithSkipApiVersion = {
+            ...defaultConfig,
+            skipApiVersion: true,
+        }
+        expect(
+            queryToResourcePath(createLink(skipApiVersionConfig), query, 'read')
+        ).toBe(`${link.unversionedApiPath}/loginConfig`)
     })
 })

--- a/services/data/src/links/RestAPILink/queryToResourcePath.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.ts
@@ -1,4 +1,4 @@
-import type { Config } from '@dhis2/app-service-config'
+import type { ConfigWithSkipApiVersion } from '@dhis2/app-service-config'
 import {
     ResolvedResourceQuery,
     QueryParameters,
@@ -71,7 +71,14 @@ const makeActionPath = (resource: string) =>
         `${resource.substr(actionPrefix.length)}.action`
     )
 
-const skipApiVersion = (resource: string, config: Config): boolean => {
+const skipApiVersion = (
+    resource: string,
+    config: ConfigWithSkipApiVersion
+): boolean => {
+    if (config?.skipApiVersion) {
+        return true
+    }
+
     if (resource === 'tracker' || resource.startsWith('tracker/')) {
         if (!config.serverVersion?.minor || config.serverVersion?.minor < 38) {
             return true

--- a/services/data/src/react/components/DataProvider.tsx
+++ b/services/data/src/react/components/DataProvider.tsx
@@ -10,6 +10,7 @@ import { DataContext } from '../context/DataContext'
 export interface ProviderInput {
     baseUrl?: string
     apiVersion?: number
+    skipApiVersion?: boolean
     children: React.ReactNode
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2734,40 +2734,6 @@
     "@dhis2/pwa" "10.2.0"
     moment "^2.24.0"
 
-"@dhis2/app-runtime@^3.6.1":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-3.9.0.tgz#c7e295fd0a68fac976a930bc77105206ded0b61a"
-  integrity sha512-n0S4pbyvK7FnBQFMONGrhR9YYavBQI+mQLHfCX/vtvOyeoioBUNIinuQlGysuLMEkSVaK5OjV40rvTMzdxF2kQ==
-  dependencies:
-    "@dhis2/app-service-alerts" "3.9.0"
-    "@dhis2/app-service-config" "3.9.0"
-    "@dhis2/app-service-data" "3.9.0"
-    "@dhis2/app-service-offline" "3.9.0"
-
-"@dhis2/app-service-alerts@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-3.9.0.tgz#48d3805676e75ee58104fea4f76cfa779335444e"
-  integrity sha512-z2eZxm/pxrmFbisbK7/qJKtif2CNWJjaaAH5rfrs5OIajlHy3rO37vSaTQHWv+xWvZFQrs2Op2InxzG0qh5ncA==
-
-"@dhis2/app-service-config@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-3.9.0.tgz#8dc59d8de246f54057c0c685d5f94b4cbade6f73"
-  integrity sha512-OuRn2mJGrQQ8QIC+oIVYYpclB4LErRK2wtsuy/cXLfRbeUti1qWIh110rgd1hnTx+BgRCs5s3NWdIQxS4hYGIQ==
-
-"@dhis2/app-service-data@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-3.9.0.tgz#37f528b5f7f589cbab8dcc7f997c1668bc6566a9"
-  integrity sha512-/FJgJhL6YGtIVNX5oaNmavkGmimrVHQsS8ueeUO4FvTjYXGlnnN3IuxypQcy/x4yiUyigbPgFJRnbC1J2af2fg==
-  dependencies:
-    react-query "^3.13.11"
-
-"@dhis2/app-service-offline@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-offline/-/app-service-offline-3.9.0.tgz#fe4f4a91a1da77554965f6a5fe6f6951d4c467f4"
-  integrity sha512-0q5zl0vw+a47Ab2qgu6hsZY5ybnH/ea43Vkk4aXYdgcf57xB8ck9DkIcNbc2e1+k9FhvimipxsgTZSbEA/8hJA==
-  dependencies:
-    lodash "^4.17.21"
-
 "@dhis2/app-shell@10.2.0":
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-10.2.0.tgz#2f69aa047dedb6545c75052d8969a80502f0d4a6"


### PR DESCRIPTION
Implements [LIBS-405](https://dhis2.atlassian.net/browse/LIBS-405)

---

### Key features

<!-- Remove if not applicable -->

1.Note this PR is a modification to app-runtime required by login_app. The main implementation of the ticket is in app-platform: https://github.com/dhis2/app-platform/pull/831

The public endpoints (e.g. api/loginConfig) do not support including version (so api/41/loginConfig is _not_ public). Hence, this PR updates to get a `skipApiVersion` passed to the Provider by app-adapter to indicate that the app should not use versions in its requests.

---

### Checklist

-   [ ] Have written Documentation
    -   _This is only an internal change for now_
-   [x] Has tests coverage





[LIBS-405]: https://dhis2.atlassian.net/browse/LIBS-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ