### PR TITLE
fix: plugin documentation typo

### DIFF
--- a/docs/components/Plugin.md
+++ b/docs/components/Plugin.md
@@ -14,7 +14,7 @@ import { Plugin } from '@dhis2/app-runtime/experimental'
 // within the app
 const MyApp = () => (
     <Plugin
-        pluginShortName={mutation}
+        pluginShortName={'myPluginShortName'}
         onError={(err) => {
             console.error(err)
         }}


### PR DESCRIPTION
This PR fixes a typo in the `<Plugin>` component documentation, `pluginShortName` property should have been a string, but I was referencing some undefined `mutation` object (I started writing this documentation by copying something else over where this was relevant 🙃)