### PR TITLE
fix(deps): remove cli-app-scripts peer dep

### DIFF
--- a/services/data/package.json
+++ b/services/data/package.json
@@ -23,15 +23,9 @@
     ],
     "peerDependencies": {
         "@dhis2/app-service-config": "3.10.3",
-        "@dhis2/cli-app-scripts": "^7.1.1",
         "prop-types": "^15.7.2",
         "react": "^16.8",
         "react-dom": "^16.8"
-    },
-    "peerDependenciesMeta": {
-        "@dhis2/cli-app-scripts": {
-            "optional": true
-        }
     },
     "scripts": {
         "build:types": "tsc --emitDeclarationOnly --outDir ./build/types",


### PR DESCRIPTION
Part of [LIBS-587](https://dhis2.atlassian.net/browse/LIBS-587); see [this comment](https://dhis2.atlassian.net/browse/LIBS-587?focusedCommentId=194633) for reasoning

To test this out, I'm thinking we can:
1. release this on alpha
2. in the app platform repo, update the `@dhis/app-runtime` dependency to alpha
3. then release an alpha of the app platform repo
4. in the d2 CLI repo, update the dependency on `@dhis2/cli-app-scripts` to the alpha version
5. release an alpha of the d2 CLI
6. then test out installing that alpha version of the CLI with npm

[LIBS-587]: https://dhis2.atlassian.net/browse/LIBS-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ