### PR TITLE
fix(deps): test out circular dependency as infinite install loop cause

### DIFF
--- a/services/data/package.json
+++ b/services/data/package.json
@@ -23,9 +23,15 @@
     ],
     "peerDependencies": {
         "@dhis2/app-service-config": "3.10.4-alpha.1",
+        "@dhis2/cli-app-scripts": "^11.1.1-alpha.1",
         "prop-types": "^15.7.2",
         "react": "^16.8",
         "react-dom": "^16.8"
+    },
+    "peerDependenciesMeta": {
+        "@dhis2/cli-app-scripts": {
+            "optional": true
+        }
     },
     "scripts": {
         "build:types": "tsc --emitDeclarationOnly --outDir ./build/types",


### PR DESCRIPTION
**Edit:** actually, I don't think a circular dependency is causing the loop that ends with `multi-calendar-dates` and starts with `cli-app-scripts` and indicates a version conflict for React. After `alpha.1` of app-runtime where the `cli-app-scripts` version conflict was fixed, app-runtime still has a dev dependency on cli-app-scripts, but no longer loops. `@dhis2/multi-calendar-dates` and `@dhis2/ui` both have only a dev dependency on `cli-app-scripts` as well (not a peer dep like `app-runtime` had before `alpha.1`), so those wouldn't be expected to loop because of that dependency

Either peer dependency version conflicts or circular dependencies can cause infinite loops during the NPM install -- adding this circular dependency but not a version conflict will test if circular dependencies do indeed cause loops, or if it's just version conflicts

Part of [LIBS-587](https://dhis2.atlassian.net/browse/LIBS-587)

[LIBS-587]: https://dhis2.atlassian.net/browse/LIBS-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ