### PR TITLE
fix(deps): remove cli-app-scripts peer dep [LIBS-587]

### DIFF
--- a/services/data/package.json
+++ b/services/data/package.json
@@ -23,15 +23,9 @@
     ],
     "peerDependencies": {
         "@dhis2/app-service-config": "3.10.3",
-        "@dhis2/cli-app-scripts": "^7.1.1",
         "prop-types": "^15.7.2",
         "react": "^16.8",
         "react-dom": "^16.8"
-    },
-    "peerDependenciesMeta": {
-        "@dhis2/cli-app-scripts": {
-            "optional": true
-        }
     },
     "scripts": {
         "build:types": "tsc --emitDeclarationOnly --outDir ./build/types",

--- a/services/data/package.json
+++ b/services/data/package.json
@@ -21,12 +21,6 @@
     "files": [
         "build/**"
     ],
-    "peerDependencies": {
-        "@dhis2/app-service-config": "3.10.3",
-        "prop-types": "^15.7.2",
-        "react": "^16.8",
-        "react-dom": "^16.8"
-    },
     "scripts": {
         "build:types": "tsc --emitDeclarationOnly --outDir ./build/types",
         "build:package": "d2-app-scripts build",
@@ -39,5 +33,11 @@
     },
     "dependencies": {
         "react-query": "^3.13.11"
+    },
+    "peerDependencies": {
+        "@dhis2/app-service-config": "3.10.3",
+        "prop-types": "^15.7.2",
+        "react": "^16.8",
+        "react-dom": "^16.8"
     }
 }


### PR DESCRIPTION
Part of [LIBS-587](https://dhis2.atlassian.net/browse/LIBS-587)

Tested out on `alpha`, this addresses an module resolution conflict on `cli-app-scripts` and fixes an infinite loop during NPM installation of the CLI.

It seems like this dependency was introduced [here](https://github.com/dhis2/app-runtime/pull/913), which I don't think was exactly correct -- App runtime doesn’t _need_ cli-app-scripts to work, since it can be implemented independently using the `Provider` — the app adapter just breaks if it doesn’t adapt to the app-runtime changes, which seems like a typical “breaking change” rather than needing a peer dependency

This PR is to the main branch to save some PRs in the future -- `@dhis2/ui` would need to be changed to use the `alpha` branch of `app-runtime` for example, and `ui` seems to have the prerelease branches in use

[LIBS-587]: https://dhis2.atlassian.net/browse/LIBS-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ