### PR TITLE
chore: v1.1.1 for query playground [LIBS-177]

### DIFF
--- a/examples/query-playground/README.md
+++ b/examples/query-playground/README.md
@@ -1,0 +1,16 @@
+### Description
+
+A playground for exploring the DHIS2 API and debugging Data Engine queries and mutations
+
+#### How to publish
+
+Since this lives in the repository with the app-runtime library, releasing new versions of this app should be done in a special way to avoid affecting the library's versions:
+
+1. Add any new changes with `chore` commits (not `fix` or `feat`)
+2. Make sure the supported DHIS2 versions are correct in `d2.config.js`
+3. Manually update the app version in `package.json` -- **Don't use `yarn version`** because we don't want to a create a git tag for this repo
+4. Add a `chore` commit for the version bump in `package.json` (make sure this will get its own commit on `master` and doesn't get squashed with others)
+5. Build the app with `yarn build`
+6. Publish the new version to the App Hub
+    1. Either on the command line using [`yarn d2-app-scripts publish`](https://developers.dhis2.org/docs/app-platform/scripts/publish/) with an API key you generated on the App Hub
+    2. Or by using the "New version" GUI on the App Hub by going to "Your Apps" => "Data Query Playground" => "New Version". This requires access to the DHIS2 organization

--- a/examples/query-playground/d2.config.js
+++ b/examples/query-playground/d2.config.js
@@ -2,6 +2,9 @@ const config = {
     title: 'Data Query Playground',
     type: 'app',
 
+    id: '99d5e87f-4948-4af6-8c0b-727c77235fd1',
+    minDHIS2Version: '2.32',
+
     entryPoints: {
         app: './src/App',
     },

--- a/examples/query-playground/package.json
+++ b/examples/query-playground/package.json
@@ -1,6 +1,6 @@
 {
     "name": "query-playground",
-    "version": "1.0.0",
+    "version": "1.1.1",
     "description": "",
     "license": "BSD-3-Clause",
     "private": true,


### PR DESCRIPTION
Implements [LIBS-177](https://dhis2.atlassian.net/browse/LIBS-177)

1. Preps for publishing to App Hub by adding App Hub ID and min DHIS2 Version
2. Adds a README with release instructions
3. Adds a commit for v1.1.1

(I'm planning on merging this PR with a `merge` commit to preserve the two commits)

[LIBS-177]: https://dhis2.atlassian.net/browse/LIBS-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ