### PR TITLE
feat: clipboard permission in plugin iframe

### DIFF
--- a/services/plugin/src/Plugin.tsx
+++ b/services/plugin/src/Plugin.tsx
@@ -167,6 +167,7 @@ export const Plugin = ({
                         height: '100%',
                         border: 'none',
                     }}
+                    allow="clipboard-write"
                 ></iframe>
             </div>
         )


### PR DESCRIPTION
This is part of https://dhis2.atlassian.net/issues/UX-136
---

### Key features

<!-- Remove if not applicable -->

Specifies that iframe generated by <Plugin> wrapper should have clipboard write access (in order for plugin error boundary to allow copying error to clipboard)
---

### Description

---

### Checklist

-   [ ] Have written Documentation
    -   This is an internal change, so I don't think we want to document.
-   [ ] Has tests coverage
    -   No 🙃. We need test coverage on plugins generally (I guess as part of becoming non-experimental)

---
