### PR TITLE
fix: update plugin sizing definition [LIBS-631]

### DIFF
--- a/services/plugin/src/Plugin.tsx
+++ b/services/plugin/src/Plugin.tsx
@@ -153,22 +153,15 @@ export const Plugin = ({
 
     if (pluginEntryPoint) {
         return (
-            <div
+            <iframe
+                ref={iframeRef}
+                src={pluginSource}
                 style={{
-                    height: `${pluginHeight}px`,
                     width: `${pluginWidth}px`,
+                    height: `${pluginHeight}px`,
+                    border: 'none',
                 }}
-            >
-                <iframe
-                    ref={iframeRef}
-                    src={pluginSource}
-                    style={{
-                        width: '100%',
-                        height: '100%',
-                        border: 'none',
-                    }}
-                ></iframe>
-            </div>
+            ></iframe>
         )
     }
 


### PR DESCRIPTION
Implements [LIBS-631](https://dhis2.atlassian.net/browse/LIBS-631)

---

### Key features

<!-- Remove if not applicable -->

Moves Plugin wrapper's definition of iframe dimensions from parent div to iframe. This is equivalent, but prevents errors with highcharts visualiztion resizing in dashboard. I have tested and this does not affect the resizing logic for plugins that are supposed to auto resize.

### Checklist

-   [ ] Have written Documentation
    -   _This change does not affect the Plugin wrapper interface, but is rather an internal implementation detail_
-   [ ] Has tests coverage
    -   _No. We need to add tests for Plugin wrapper as part of work to make non-experimental_

---


[LIBS-631]: https://dhis2.atlassian.net/browse/LIBS-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ