### PR TITLE
fix(cacheable-section): stable references to avoid loops [LIBS-642]

### DIFF
--- a/services/offline/src/lib/__tests__/cacheable-section-state.test.tsx
+++ b/services/offline/src/lib/__tests__/cacheable-section-state.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react-hooks'
+import React, { FC } from 'react'
+import { mockOfflineInterface } from '../../utils/test-mocks'
+import { useCachedSection, useRecordingState } from '../cacheable-section-state'
+import { OfflineProvider } from '../offline-provider'
+
+const wrapper: FC = ({ children }) => (
+    <OfflineProvider offlineInterface={mockOfflineInterface}>
+        {children}
+    </OfflineProvider>
+)
+
+test('useRecordingState has basically stable references', () => {
+    const { result, rerender } = renderHook(() => useRecordingState('one'), {
+        wrapper,
+    })
+
+    const origRecordingState = result.current.recordingState
+    const origSetRecordingState = result.current.setRecordingState
+    const origRemoveRecordingState = result.current.removeRecordingState
+
+    rerender()
+
+    expect(result.current.recordingState).toBe(origRecordingState)
+    expect(result.current.setRecordingState).toBe(origSetRecordingState)
+    expect(result.current.removeRecordingState).toBe(origRemoveRecordingState)
+})
+
+test('useCachedSection has basically stable references', () => {
+    const { result, rerender } = renderHook(() => useCachedSection('one'), {
+        wrapper,
+    })
+
+    const origIsCached = result.current.isCached
+    const origLastUpdated = result.current.lastUpdated
+    const origRemove = result.current.remove
+    const origSyncCachedSections = result.current.syncCachedSections
+
+    rerender()
+
+    expect(result.current.isCached).toBe(origIsCached)
+    expect(result.current.lastUpdated).toBe(origLastUpdated)
+    expect(result.current.remove).toBe(origRemove)
+    expect(result.current.syncCachedSections).toBe(origSyncCachedSections)
+})

--- a/services/offline/src/lib/__tests__/cacheable-section-state.test.tsx
+++ b/services/offline/src/lib/__tests__/cacheable-section-state.test.tsx
@@ -10,7 +10,7 @@ const wrapper: FC = ({ children }) => (
     </OfflineProvider>
 )
 
-test('useRecordingState has basically stable references', () => {
+test('useRecordingState has stable references', () => {
     const { result, rerender } = renderHook(() => useRecordingState('one'), {
         wrapper,
     })
@@ -26,7 +26,7 @@ test('useRecordingState has basically stable references', () => {
     expect(result.current.removeRecordingState).toBe(origRemoveRecordingState)
 })
 
-test('useCachedSection has basically stable references', () => {
+test('useCachedSection has stable references', () => {
     const { result, rerender } = renderHook(() => useCachedSection('one'), {
         wrapper,
     })

--- a/services/offline/src/lib/__tests__/use-cacheable-section.test.tsx
+++ b/services/offline/src/lib/__tests__/use-cacheable-section.test.tsx
@@ -41,6 +41,31 @@ it('renders in the default state initially', () => {
     expect(result.current.lastUpdated).toBeUndefined()
 })
 
+it('has stable references', () => {
+    const wrapper: FC = ({ children }) => (
+        <OfflineProvider offlineInterface={mockOfflineInterface}>
+            {children}
+        </OfflineProvider>
+    )
+    const { result, rerender } = renderHook(() => useCacheableSection('one'), {
+        wrapper,
+    })
+
+    const origRecordingState = result.current.recordingState
+    const origStartRecording = result.current.startRecording
+    const origLastUpdated = result.current.lastUpdated
+    const origIsCached = result.current.isCached
+    const origRemove = result.current.remove
+
+    rerender()
+
+    expect(result.current.recordingState).toBe(origRecordingState)
+    expect(result.current.startRecording).toBe(origStartRecording)
+    expect(result.current.lastUpdated).toBe(origLastUpdated)
+    expect(result.current.isCached).toBe(origIsCached)
+    expect(result.current.remove).toBe(origRemove)
+})
+
 it('handles a successful recording', async (done) => {
     const [sectionId, timeoutDelay] = ['one', 1234]
     const testOfflineInterface = {

--- a/services/offline/src/lib/cacheable-section.tsx
+++ b/services/offline/src/lib/cacheable-section.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import { RecordingState } from '../types'
 import { useRecordingState, useCachedSection } from './cacheable-section-state'
 import { useOfflineInterface } from './offline-interface'
@@ -61,60 +61,77 @@ export function useCacheableSection(id: string): CacheableSectionControls {
                 removeRecordingState()
             }
         }
+        // todo: avoid dependency on recordingState
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-    function startRecording({
-        recordingTimeoutDelay = 1000,
-        onStarted,
-        onCompleted,
-        onError,
-    }: CacheableSectionStartRecordingOptions = {}) {
-        // This promise resolving means that the message to the service worker
-        // to start recording was successful. Waiting for resolution prevents
-        // unnecessarily rerendering the whole component in case of an error
-        return offlineInterface
-            .startRecording({
-                sectionId: id,
-                recordingTimeoutDelay,
-                onStarted: () => {
-                    onRecordingStarted()
-                    onStarted && onStarted()
-                },
-                onCompleted: () => {
-                    onRecordingCompleted()
-                    onCompleted && onCompleted()
-                },
-                onError: (error) => {
-                    onRecordingError(error)
-                    onError && onError(error)
-                },
-            })
-            .then(() => setRecordingState(recordingStates.pending))
-    }
-
-    function onRecordingStarted() {
+    const onRecordingStarted = useCallback(() => {
         setRecordingState(recordingStates.recording)
-    }
+    }, [setRecordingState])
 
-    function onRecordingCompleted() {
+    const onRecordingCompleted = useCallback(() => {
         setRecordingState(recordingStates.default)
         syncCachedSections()
-    }
+    }, [setRecordingState, syncCachedSections])
 
-    function onRecordingError(error: Error) {
-        console.error('Error during recording:', error)
-        setRecordingState(recordingStates.error)
-    }
+    const onRecordingError = useCallback(
+        (error: Error) => {
+            console.error('Error during recording:', error)
+            setRecordingState(recordingStates.error)
+        },
+        [setRecordingState]
+    )
+
+    const startRecording = useCallback(
+        ({
+            recordingTimeoutDelay = 1000,
+            onStarted,
+            onCompleted,
+            onError,
+        }: CacheableSectionStartRecordingOptions = {}) => {
+            // This promise resolving means that the message to the service worker
+            // to start recording was successful. Waiting for resolution prevents
+            // unnecessarily rerendering the whole component in case of an error
+            return offlineInterface
+                .startRecording({
+                    sectionId: id,
+                    recordingTimeoutDelay,
+                    onStarted: () => {
+                        onRecordingStarted()
+                        onStarted && onStarted()
+                    },
+                    onCompleted: () => {
+                        onRecordingCompleted()
+                        onCompleted && onCompleted()
+                    },
+                    onError: (error) => {
+                        onRecordingError(error)
+                        onError && onError(error)
+                    },
+                })
+                .then(() => setRecordingState(recordingStates.pending))
+        },
+        [
+            id,
+            offlineInterface,
+            onRecordingCompleted,
+            onRecordingError,
+            onRecordingStarted,
+            setRecordingState,
+        ]
+    )
 
     // isCached, lastUpdated, remove: _could_ be accessed by useCachedSection,
     // but provided through this hook for convenience
-    return {
-        recordingState,
-        startRecording,
-        lastUpdated,
-        isCached,
-        remove,
-    }
+    return useMemo(
+        () => ({
+            recordingState,
+            startRecording,
+            lastUpdated,
+            isCached,
+            remove,
+        }),
+        [recordingState, startRecording, lastUpdated, isCached, remove]
+    )
 }
 
 interface CacheableSectionProps {

--- a/services/offline/src/lib/cacheable-section.tsx
+++ b/services/offline/src/lib/cacheable-section.tsx
@@ -61,7 +61,6 @@ export function useCacheableSection(id: string): CacheableSectionControls {
                 removeRecordingState()
             }
         }
-        // todo: avoid dependency on recordingState
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     const onRecordingStarted = useCallback(() => {

--- a/services/offline/src/lib/global-state-service.tsx
+++ b/services/offline/src/lib/global-state-service.tsx
@@ -1,6 +1,12 @@
 import isEqual from 'lodash/isEqual'
 import PropTypes from 'prop-types'
-import React, { useEffect, useCallback, useContext, useState } from 'react'
+import React, {
+    useEffect,
+    useCallback,
+    useContext,
+    useState,
+    useMemo,
+} from 'react'
 import {
     GlobalStateStore,
     GlobalStateStoreMutateMethod,
@@ -79,9 +85,14 @@ export const useGlobalState = (
         // Make sure to update state when selector changes
         callback(store.getState())
         return () => store.unsubscribe(callback)
+        // todo: refactor to use setSelectedState(selectedState => ...) to avoid
+        // requiring selectedState as a dependency
     }, [store, selector]) /* eslint-disable-line react-hooks/exhaustive-deps */
 
-    return [selectedState, store.mutate]
+    return useMemo(
+        () => [selectedState, store.mutate],
+        [selectedState, store.mutate]
+    )
 }
 
 export function useGlobalStateMutation<Type>(

--- a/services/offline/src/lib/global-state-service.tsx
+++ b/services/offline/src/lib/global-state-service.tsx
@@ -72,22 +72,24 @@ export const useGlobalState = (
         // NEW: deep equality check before updating
         const callback = (state: any) => {
             const newSelectedState = selector(state)
-            // Second condition handles case where a selected object gets
-            // deleted, but state does not update
-            if (
-                !isEqual(selectedState, newSelectedState) ||
-                selectedState === undefined
-            ) {
-                setSelectedState(newSelectedState)
-            }
+            // Use this form to avoid having `selectedState` as a dep in here
+            setSelectedState((currentSelectedState: any) => {
+                // Second condition handles case where a selected object gets
+                // deleted, but state does not update
+                if (
+                    !isEqual(currentSelectedState, newSelectedState) ||
+                    currentSelectedState === undefined
+                ) {
+                    return newSelectedState
+                }
+                return currentSelectedState
+            })
         }
         store.subscribe(callback)
         // Make sure to update state when selector changes
         callback(store.getState())
         return () => store.unsubscribe(callback)
-        // todo: refactor to use setSelectedState(selectedState => ...) to avoid
-        // requiring selectedState as a dependency
-    }, [store, selector]) /* eslint-disable-line react-hooks/exhaustive-deps */
+    }, [store, selector])
 
     return useMemo(
         () => [selectedState, store.mutate],


### PR DESCRIPTION
Implements [LIBS-642](https://dhis2.atlassian.net/browse/LIBS-642)

These hooks were implemented unoptimally, admittedly, and functions were getting recreated on each render. This caused issues if they were used as dependencies for `useEffect` hooks, like an infinite loop demoed below

I've updated the hooks to use best practices with `useCallback` and `useMemo` to make stable references and minimize unnecessary rerenders, and I added some automated tests to help verify the stability -- the tests look simplistic, but they were failing before the changes, and actually helped track down which hooks were still unstable in a TDD way

I also tested manually with the PWA example app in the App Platform, with some code that looks like an [implementation in analytics plugins](https://github.com/dhis2/data-visualizer-app/blob/c39ec70e22c32ffe0cfeddffbf55f5e3a6f08ba0/src/PluginWrapper.js#L33-L36):
```js
useEffect(() => {
    if (shouldRecord) {
        startRecording()
    }
}, [shouldRecord, startRecording])
```

Demo of loop:

https://github.com/user-attachments/assets/38500742-de17-4853-91bc-0879ab6eecb8


After changes:

https://github.com/user-attachments/assets/d072f6f3-1b51-4a79-8bd2-69ee9429a3af




[LIBS-642]: https://dhis2.atlassian.net/browse/LIBS-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ