### PR TITLE
fix: handle async parentAlertsAdd

### DIFF
--- a/services/alerts/src/useAlert.ts
+++ b/services/alerts/src/useAlert.ts
@@ -27,7 +27,7 @@ export const useAlert = (
                     },
                     alertRef
                     // Conditional chaining gives backwards compatibility
-                    // with cli-app-scripts < 11.7.2
+                    // with cli-app-scripts < 12
                 )?.then((newAlert: Alert) => {
                     alertRef.current = newAlert
                 })

--- a/services/alerts/src/useAlert.ts
+++ b/services/alerts/src/useAlert.ts
@@ -19,13 +19,18 @@ export const useAlert = (
                 typeof options === 'function' ? options(props) : options
 
             if (plugin && parentAlertsAdd && !showAlertsInPlugin) {
-                alertRef.current = parentAlertsAdd(
+                // Functions passed through post-robot are asynchronous
+                parentAlertsAdd(
                     {
                         message: resolvedMessage,
                         options: resolvedOptions,
                     },
                     alertRef
-                )
+                    // Conditional chaining gives backwards compatibility
+                    // with cli-app-scripts < 11.7.2
+                )?.then((newAlert: Alert) => {
+                    alertRef.current = newAlert
+                })
             } else {
                 alertRef.current = add(
                     {


### PR DESCRIPTION
Part of [LIBS-695](https://dhis2.atlassian.net/browse/LIBS-695) -- see also the accompanying PR in the app-platform, https://github.com/dhis2/app-platform/pull/881

The change here handles the `parentAlertsAdd` function as asynchronous, since that's how post-robot [handles functions passed between windows](https://github.com/krakenjs/post-robot?tab=readme-ov-file#functions) -- it also uses optional chaining to work with previous versions of the app-shell/Plugin Loader

In the app-platform, there's just a small tweak to fix the `parentAlertsAdd` function by returning its result to the plugin

### Screenshots



https://github.com/user-attachments/assets/4e041be2-4ae5-4c48-b134-82ad37fa5c5a



[LIBS-695]: https://dhis2.atlassian.net/browse/LIBS-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ