### PR TITLE
fix: expand FetchErrorDetails type

### DIFF
--- a/services/data/src/engine/types/FetchError.ts
+++ b/services/data/src/engine/types/FetchError.ts
@@ -1,5 +1,12 @@
 export type FetchErrorTypeName = 'network' | 'unknown' | 'access' | 'aborted'
-export type FetchErrorDetails = { message?: string }
+export type FetchErrorDetails = {
+    errorCode?: number
+    httpStatus?: string
+    httpStatusCode?: number
+    message?: string
+    status?: string
+    [x: string]: any
+}
 
 export interface FetchErrorPayload {
     type: FetchErrorTypeName

--- a/services/data/src/engine/types/FetchError.ts
+++ b/services/data/src/engine/types/FetchError.ts
@@ -1,10 +1,10 @@
 export type FetchErrorTypeName = 'network' | 'unknown' | 'access' | 'aborted'
 export type FetchErrorDetails = {
-    errorCode?: number
     httpStatus?: string
     httpStatusCode?: number
-    message?: string
     status?: string
+    message?: string
+    errorCode?: string
     [x: string]: any
 }
 


### PR DESCRIPTION
Noticed when using error details here: https://github.com/dhis2/reference-civil-registry-lookup/blob/069d664aa7d3c653c8a46c050c8e61d75eb327b4/civil-registry-plugin/src/LookupField/LookupField.tsx#L69-L72

This type should be flexible since details can vary, but provide some autocomplete for common properties

Here's an example `error.details` from a Route mutation:
```js
{
    httpStatus: 'Not Found',
    httpStatusCode: 404,
    status: 'ERROR',
    message: 'Route does-not-exist not found',
    errorCode: 'E1005',
}
```

Some error details just end up as `{}`, as in some GET 404 responses
