### PR TITLE
fix: add endpoint to text plain matchers

### DIFF
--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
@@ -258,4 +258,18 @@ describe('isExpressionDescriptionValidation', () => {
             })
         ).toBe(false)
     })
+    it('returns true for a POST to "programIndicators/expression/description"', () => {
+        expect(
+            isExpressionDescriptionValidation('create', {
+                resource: 'programIndicators/expression/description',
+            })
+        ).toBe(true)
+    })
+    it('retuns false for a POST to a different resource', () => {
+        expect(
+            isMetadataPackageInstallation('create', {
+                resource: 'programIndicators/expression/somethingelse',
+            })
+        ).toBe(false)
+    })
 })

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
@@ -122,9 +122,11 @@ export const isMetadataPackageInstallation = (
     { resource }: ResolvedResourceQuery
 ): boolean => type === 'create' && resource === 'synchronization/metadataPull'
 
-// POST to 'indicaators/expression/description' (validate an expression)
+// POST to 'indicators/expression/description' or 'programIndicator/expression/description' (validate an expression)
 export const isExpressionDescriptionValidation = (
     type: FetchType,
     { resource }: ResolvedResourceQuery
-): boolean =>
-    type === 'create' && resource === 'indicators/expression/description'
+): boolean => {
+    const pattern = /^(indicators|programIndicators)\/expression\/description$/
+    return type === 'create' && pattern.test(resource)
+}


### PR DESCRIPTION

### Key features

1. `programIndicators/expression/description` wants a plain text payload

---

### Description

This is similar to `indicators/expression/description`.
The same function matches now both URLs as they are both about getting an expression in human readable format.

---

### Checklist

-   [ ] Have written Documentation
    -   _If not needed, explain why, otherwise remove this bullet point_
-   [ ] Has tests coverage
    -   _If not needed, explain why, otherwise remove this bullet point_