### PR TITLE
fix: reference module types in package.json export declaration [LIBS-740]

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -8,11 +8,13 @@
     "exports": {
         ".": {
             "import": "./build/es/index.js",
-            "require": "./build/cjs/index.js"
+            "require": "./build/cjs/index.js",
+            "types": "./build/types/index.d.ts"
         },
         "./experimental": {
             "import": "./build/es/experimental.js",
-            "require": "./build/cjs/experimental.js"
+            "require": "./build/cjs/experimental.js",
+            "types": "./build/types/experimental.d.ts"
         }
     },
     "repository": {

--- a/services/alerts/package.json
+++ b/services/alerts/package.json
@@ -6,7 +6,8 @@
     "types": "./build/types/index.d.ts",
     "exports": {
         "import": "./build/es/index.js",
-        "require": "./build/cjs/index.js"
+        "require": "./build/cjs/index.js",
+        "types": "./build/types/index.d.ts"
     },
     "repository": {
         "type": "git",

--- a/services/config/package.json
+++ b/services/config/package.json
@@ -6,7 +6,8 @@
     "types": "build/types/index.d.ts",
     "exports": {
         "import": "./build/es/index.js",
-        "require": "./build/cjs/index.js"
+        "require": "./build/cjs/index.js",
+        "types": "./build/types/index.d.ts"
     },
     "repository": {
         "type": "git",

--- a/services/data/package.json
+++ b/services/data/package.json
@@ -6,7 +6,8 @@
     "types": "build/types/index.d.ts",
     "exports": {
         "import": "./build/es/index.js",
-        "require": "./build/cjs/index.js"
+        "require": "./build/cjs/index.js",
+        "types": "./build/types/index.d.ts"
     },
     "repository": {
         "type": "git",

--- a/services/offline/package.json
+++ b/services/offline/package.json
@@ -7,7 +7,8 @@
     "types": "build/types/index.d.ts",
     "exports": {
         "import": "./build/es/index.js",
-        "require": "./build/cjs/index.js"
+        "require": "./build/cjs/index.js",
+        "types": "./build/types/index.d.ts"
     },
     "repository": {
         "type": "git",

--- a/services/plugin/package.json
+++ b/services/plugin/package.json
@@ -6,7 +6,8 @@
     "types": "build/types/index.d.ts",
     "exports": {
         "import": "./build/es/index.js",
-        "require": "./build/cjs/index.js"
+        "require": "./build/cjs/index.js",
+        "types": "./build/types/index.d.ts"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Implements [LIBS-740](https://dhis2.atlassian.net/browse/LIBS-740)

---

### Key features

Adds type definition exports to package.json so that consumers can find the right types.

[LIBS-740]: https://dhis2.atlassian.net/browse/LIBS-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ