### PR TITLE
fix(plugin): don't update props when plugin width or height props change

### DIFF
--- a/services/plugin/src/Plugin.tsx
+++ b/services/plugin/src/Plugin.tsx
@@ -129,6 +129,12 @@ export const Plugin = ({
         }
     }, [pluginEntryPoint])
 
+    // Tracking these as booleans means they can be used as dependencies for
+    // the useEffect to update props without triggering updates everytime their
+    // string/number value changes
+    const heightIsContentDriven = !height
+    const widthIsContentDriven = !width && clientWidth
+
     // Set up communication listeners: if we haven't gotten a message from the
     // plugin, set up a listener for its request for initial props. If we have
     // received communication from the plugin, then on any props update, we can
@@ -145,8 +151,8 @@ export const Plugin = ({
             // don't send a resize callback to the plugin. The plugin can
             // use the presence or absence of these callbacks to determine
             // how to handle sizing inside
-            setPluginHeight: !height ? setPluginHeight : null,
-            setPluginWidth: !width && clientWidth ? setPluginWidth : null,
+            setPluginHeight: heightIsContentDriven ? setPluginHeight : null,
+            setPluginWidth: widthIsContentDriven ? setPluginWidth : null,
             setInErrorState,
             clientWidth,
         }
@@ -179,9 +185,14 @@ export const Plugin = ({
                     console.error(err)
                 })
         }
-        // Skip `width` and `height` props to avoid updates when changing size:
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [memoizedPropsToPass, inErrorState, alertsAdd, clientWidth])
+    }, [
+        memoizedPropsToPass,
+        inErrorState,
+        alertsAdd,
+        heightIsContentDriven,
+        widthIsContentDriven,
+        clientWidth,
+    ])
 
     if (data && !pluginEntryPoint) {
         return (

--- a/services/plugin/src/Plugin.tsx
+++ b/services/plugin/src/Plugin.tsx
@@ -179,15 +179,9 @@ export const Plugin = ({
                     console.error(err)
                 })
         }
-    }, [
-        memoizedPropsToPass,
-        inErrorState,
-        // The following should be pretty stable:
-        alertsAdd,
-        clientWidth,
-        height,
-        width,
-    ])
+        // Skip `width` and `height` props to avoid updates when changing size:
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [memoizedPropsToPass, inErrorState, alertsAdd, clientWidth])
 
     if (data && !pluginEntryPoint) {
         return (


### PR DESCRIPTION
Accidentally introduced this in 3.13.1 -- useEffect dependencies retrigger props updates, which causes unnecessary refetches in plugins

Before:


https://github.com/user-attachments/assets/fe9d9007-b83e-4ee5-a13d-4cbb719aed06


After:

https://github.com/user-attachments/assets/78d87456-1277-4a42-a8e9-67132b2d1271


