### PR TITLE
feat: enable querying apps-bundle.json

### DIFF
--- a/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.test.ts
@@ -41,6 +41,26 @@ describe('queryToResourcePath', () => {
             )
         })
     })
+    describe('legacy', () => {
+        it('should return the apps bundle url if using `legacy::bundledApps`', () => {
+            const query: ResolvedResourceQuery = {
+                resource: 'legacy::bundledApps',
+            }
+            expect(queryToResourcePath(link, query, 'read')).toBe(
+                'dhis-web-apps/apps-bundle.json'
+            )
+            console.log({ apiPath })
+        })
+        it('should return the specified path if using `legacy::<customPath>`', () => {
+            const query: ResolvedResourceQuery = {
+                resource: 'legacy::dhis-web-apps',
+            }
+            expect(queryToResourcePath(link, query, 'read')).toBe(
+                'dhis-web-apps'
+            )
+            console.log({ apiPath })
+        })
+    })
     describe('resource with dot', () => {
         it('should leave dots in resources', () => {
             const query: ResolvedResourceQuery = {

--- a/services/data/src/links/RestAPILink/queryToResourcePath.ts
+++ b/services/data/src/links/RestAPILink/queryToResourcePath.ts
@@ -71,6 +71,21 @@ const makeActionPath = (resource: string) =>
         `${resource.substr(actionPrefix.length)}.action`
     )
 
+const legacyPrefix = 'legacy::'
+const isLegacy = (resource: string) => resource.startsWith(legacyPrefix)
+const makeLegacyPath = (resource: string) => {
+    switch (resource) {
+        case 'legacy::bundledApps': {
+            return 'dhis-web-apps/apps-bundle.json'
+        }
+        // Not necessary here, but brainstorming:
+        // you can use whatever path you want 🤷
+        default: {
+            return resource.replace(legacyPrefix, '')
+        }
+    }
+}
+
 const skipApiVersion = (resource: string, config: Config): boolean => {
     if (resource === 'tracker' || resource.startsWith('tracker/')) {
         if (!config.serverVersion?.minor || config.serverVersion?.minor < 38) {
@@ -99,6 +114,8 @@ export const queryToResourcePath = (
 
     const base = isAction(resource)
         ? makeActionPath(resource)
+        : isLegacy(resource)
+        ? makeLegacyPath(resource)
         : joinPath(apiBase, resource, id)
 
     validateResourceQuery(query, type)


### PR DESCRIPTION
Proof of concept; useful for getting versions of bundled apps -- usable by Dashboard to get plugin versions, and by Global Shell to get versions of the loaded apps

* The logic could just be `resource === 'legacy::bundledApps' ? 'dhis-web-apps/apps-bundle.json' : ...`, but I thought of opening up other endpoints for useDataQuery