### PR TITLE
fix: add endpoint to text plain matchers

### DIFF
--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   node-version: 20.x
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v4
               id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
                   path: '**/node_modules'
@@ -44,7 +44,7 @@ jobs:
               with:
                   node-version: 20.x
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v4
               id: yarn-cache
               with:
                   path: '**/node_modules'
@@ -71,7 +71,7 @@ jobs:
               with:
                   node-version: 20.x
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v4
               id: yarn-cache
               with:
                   path: '**/node_modules'
@@ -98,7 +98,7 @@ jobs:
               with:
                   node-version: 20.x
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v4
               id: yarn-cache
               with:
                   path: '**/node_modules'

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
@@ -254,7 +254,7 @@ describe('isExpressionDescriptionValidation', () => {
     })
     it('retuns false for a POST to a different resource', () => {
         expect(
-            isMetadataPackageInstallation('create', {
+            isExpressionDescriptionValidation('create', {
                 resource: 'indicators/expression/somethingelse',
             })
         ).toBe(false)
@@ -268,7 +268,7 @@ describe('isExpressionDescriptionValidation', () => {
     })
     it('retuns false for a POST to a different resource', () => {
         expect(
-            isMetadataPackageInstallation('create', {
+            isExpressionDescriptionValidation('create', {
                 resource: 'programIndicators/expression/somethingelse',
             })
         ).toBe(false)
@@ -285,7 +285,7 @@ describe('isFilterDescriptionValidation', () => {
     })
     it('retuns false for a POST to a different resource', () => {
         expect(
-            isMetadataPackageInstallation('create', {
+            isFilterDescriptionValidation('create', {
                 resource: 'programIndicators/filter/somethingelse',
             })
         ).toBe(false)

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.test.ts
@@ -9,6 +9,7 @@ import {
     addOrUpdateConfigurationProperty,
     isMetadataPackageInstallation,
     isExpressionDescriptionValidation,
+    isFilterDescriptionValidation,
 } from './textPlainMatchers'
 
 describe('isReplyToMessageConversation', () => {
@@ -269,6 +270,23 @@ describe('isExpressionDescriptionValidation', () => {
         expect(
             isMetadataPackageInstallation('create', {
                 resource: 'programIndicators/expression/somethingelse',
+            })
+        ).toBe(false)
+    })
+})
+
+describe('isFilterDescriptionValidation', () => {
+    it('returns true for a POST to "programIndicators/filter/description"', () => {
+        expect(
+            isFilterDescriptionValidation('create', {
+                resource: 'programIndicators/filter/description',
+            })
+        ).toBe(true)
+    })
+    it('retuns false for a POST to a different resource', () => {
+        expect(
+            isMetadataPackageInstallation('create', {
+                resource: 'programIndicators/filter/somethingelse',
             })
         ).toBe(false)
     })

--- a/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
+++ b/services/data/src/links/RestAPILink/queryToRequestOptions/textPlainMatchers.ts
@@ -130,3 +130,12 @@ export const isExpressionDescriptionValidation = (
     const pattern = /^(indicators|programIndicators)\/expression\/description$/
     return type === 'create' && pattern.test(resource)
 }
+
+// POST to 'programIndicator/filter/description' (validate a filter)
+export const isFilterDescriptionValidation = (
+    type: FetchType,
+    { resource }: ResolvedResourceQuery
+): boolean => {
+    const pattern = /^programIndicators\/filter\/description$/
+    return type === 'create' && pattern.test(resource)
+}


### PR DESCRIPTION
### Key features

1. `programIndicators/filter/description` wants a plain text payload

---

### Description

This is similar to `programIndicators/expression/description`.

---

### Checklist

-   [ ] Have written Documentation
    -   _Not needed as this is fully internal_
-   [x] Has tests coverage
