### PR TITLE
feat(offline): keep pings active while focus is in iframes

### DIFF
--- a/services/offline/src/lib/dhis2-connection-status/dhis2-connection-status.tsx
+++ b/services/offline/src/lib/dhis2-connection-status/dhis2-connection-status.tsx
@@ -151,8 +151,16 @@ export const Dhis2ConnectionStatusProvider = ({
         })
         smartIntervalRef.current = smartInterval
 
-        const handleBlur = () => smartInterval.pause()
-        const handleFocus = () => smartInterval.resume()
+        // Use visibility change instead of focus/blur to continue while focus
+        // might be in iframes
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'hidden') {
+                smartInterval.pause()
+            } else {
+                // visibilityState === 'visible'
+                smartInterval.resume()
+            }
+        }
         // Pinging when going offline should be low/no-cost in both online and
         // local servers
         const handleOffline = () => smartInterval.invokeCallbackImmediately()
@@ -163,14 +171,15 @@ export const Dhis2ConnectionStatusProvider = ({
             15000
         )
 
-        window.addEventListener('blur', handleBlur)
-        window.addEventListener('focus', handleFocus)
+        document.addEventListener('visibilitychange', handleVisibilityChange)
         window.addEventListener('offline', handleOffline)
         window.addEventListener('online', handleOnline)
 
         return () => {
-            window.removeEventListener('blur', handleBlur)
-            window.removeEventListener('focus', handleFocus)
+            document.removeEventListener(
+                'visibilitychange',
+                handleVisibilityChange
+            )
             window.removeEventListener('offline', handleOffline)
             window.removeEventListener('online', handleOnline)
 


### PR DESCRIPTION
Related to [DHIS2-19285](https://dhis2.atlassian.net/browse/DHIS2-19285)

Uses document visibility to decide whether to ping instead of window focus. Window focus can be insufficient if focus is in `iframe`s on the page, as seen in the Jira issue above

A downside is that this may lead to multiple apps in `iframe`s in a page all issuing pings -- I think using document visibility vs window focus **should be a configurable thing**, so an app like the global shell can still update its online status with pings as long as the page is visible, while all other apps only update with pings when focused. The latter has been working so far, since apps generally need to know the status once they're interacted with. I don't think we want the dashboard app and all its plugins sending pings, for example

This PR is in a draft while that configuration is considered

### Checklist

-   [ ] Have written Documentation
-   [ ] Has tests coverage

### Screenshots

In action in the global shell:


https://github.com/user-attachments/assets/d828b39d-6b4c-4144-88b3-4244fed33b46



