### PR TITLE
fix: expose TS types internal to the data engine

### DIFF
--- a/.github/workflows/dhis2-deploy-netlify.yml
+++ b/.github/workflows/dhis2-deploy-netlify.yml
@@ -27,8 +27,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 20.x
-
-            - uses: c-hive/gha-yarn-cache@v1
+                  cache: 'yarn'
             - run: yarn install --frozen-lockfile
 
             - run: |

--- a/.github/workflows/dhis2-verify-commits.yml
+++ b/.github/workflows/dhis2-verify-commits.yml
@@ -9,7 +9,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: c-hive/gha-yarn-cache@v1
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+                  cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
@@ -24,7 +27,10 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-            - uses: c-hive/gha-yarn-cache@v1
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+                  cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "rimraf": "^3.0.0",
-        "typescript": "^4.9.5"
+        "typescript": "^5.7.3"
     },
     "scripts": {
         "install:examples": "loop \"yarn install --force --check-files\" --cwd ./examples --exit-on-aggregate-error",

--- a/services/data/src/index.ts
+++ b/services/data/src/index.ts
@@ -8,3 +8,5 @@ export {
 export { useDataEngine, useDataQuery, useDataMutation } from './react'
 
 export { FetchError } from './engine'
+
+export type * from './types'

--- a/yarn.lock
+++ b/yarn.lock
@@ -12483,15 +12483,15 @@ typeface-roboto@^0.0.75:
   resolved "https://registry.yarnpkg.com/typeface-roboto/-/typeface-roboto-0.0.75.tgz#98d5ba35ec234bbc7172374c8297277099cc712b"
   integrity sha512-VrR/IiH00Z1tFP4vDGfwZ1esNqTiDMchBEXYY9kilT6wRGgFoCAlgkEUMHb1E3mB0FsfZhv756IF0+R+SFPfdg==
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
 typescript@^5.6.3:
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
+
+typescript@^5.7.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.39"


### PR DESCRIPTION
This exposes the types in Data service which are often needed by consumers of the app-runtime but currently are not exposed. This led consumers to have to do various workarounds in order to _pluck_ these types, like [this](https://github.com/dhis2/maintenance-app-beta/blob/master/src/lib/dataStore/useDataStore.ts#L11) for example.

 Which this change, the types can be accessed from the top level, i.e. `import {QueryRefetchFunction} from 'dhis2/app-runtime'`


## Notes
1. Instead of exporting at the top-level, I looked at exporting the types to `@dhis2/app-runtime/types`. This was mainly as I assumed that the initial intention was these types are internal, so didn't want to make them _too_ obvious. But on second thought, I thought this was unnecessary and looking at other libraries - React for instance - it seems common to expose such types at the top-level.

2. In some of the services, i.e. [config service](https://github.com/dhis2/app-runtime/blob/92497bedaee136d3ffc53b0865b609c00e6e3fe4/services/config/src/index.ts#L5-L6) we explicitly exported some of the types in `/types.ts`  rather than everything - in this PR, I am exposing everything there, mainly because everything in types.ts seems to be useful in the context of Data Provider.

3. Some other services `Offline` still don't export the types defined in `./types.ts`,  I left them for now - it seems like the workarounds are mostly needed for the types under the Data provider - if a need arises to export the other ones, we can do so later. 

4. In order to be able to do `export type * from ...`, rather than importing and then re-exporting under a namespace, I updated TS version in the devDependencies to version 5 - this is also the version used by the app-shell and the one hoisted by default in dhis2 apps, so this actually brings the runtime consistent with app-shell and platform. 

Implements [LIBS-769](https://dhis2.atlassian.net/browse/LIBS-769)


[LIBS-769]: https://dhis2.atlassian.net/browse/LIBS-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ